### PR TITLE
Editorial redesign: apply design_handoff_tthew_website to the site

### DIFF
--- a/_config/filters.js
+++ b/_config/filters.js
@@ -95,8 +95,44 @@ export default function (eleventyConfig) {
 			return true;
 		});
 	});
-	
-	eleventyConfig.addFilter("TIL", (words) => words.pageType === 'TIL')
+
+	// Inclusive public-web filter: everything except rssOnly posts, so the
+	// Words index can surface Articles, TIL and Note kinds together.
+	eleventyConfig.addFilter("allWebWords", (words) => {
+		return (words || []).filter(({ rssOnly }) => !rssOnly);
+	});
+
+	// Group a sorted array of posts by year. Returns an array of
+	// { year, posts } pairs with years descending and posts within each
+	// year in the input order.
+	eleventyConfig.addFilter("groupByYear", (words) => {
+		const groups = new Map();
+		for (const post of words || []) {
+			const year = new Date(post.date).getUTCFullYear();
+			if (!groups.has(year)) groups.set(year, []);
+			groups.get(year).push(post);
+		}
+		return [...groups.entries()]
+			.sort((a, b) => b[0] - a[0])
+			.map(([year, posts]) => ({ year, posts }));
+	});
+
+	// Human-readable label for a post's kind; empty string when not set.
+	eleventyConfig.addFilter("postKindLabel", (postType) => {
+		switch (postType) {
+			case 'Article':
+			case '':
+			case undefined:
+			case null:
+				return 'Essay';
+			case 'TIL':
+				return 'TIL';
+			case 'Note':
+				return 'Note';
+			default:
+				return postType;
+		}
+	});
 
 	eleventyConfig.addFilter("markdown", (content) => {
 		return markdown.render(content);

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -37,25 +37,16 @@
 	<a href="#skip" class="visually-hidden">Skip to main content</a>
 
 	<header>
-		<div>
 		<a href="/" class="home-link">@{{ metadata.title }}</a>
-		<nav>
+		<nav aria-label="Primary">
 			<h2 class="visually-hidden">Top level navigation menu</h2>
 			<ul class="nav">
-				<li class="nav-item"><a href="/" {% if "/"==page.url %} aria-current="page" {% endif %}>Home</a></li>
-				<li class="nav-item"><a href="/about" {% if "/about/"==page.url %} aria-current="page" {% endif
-						%}>About</a></li>
-				<li class="nav-item"><a href="/words" {% if "/words/"==page.url %} aria-current="page" {% endif
-						%}>Words</a></li>
-				{# <li class="nav-item"><a href="/til" {% if "/til/"==page.url %} aria-current="page" {% endif
-						%}><abbr title="Today I Learned">TIL</abbr></a></li> #}
-				<li class="nav-item"><a href="/contact" {% if "/contact/"==page.url %} aria-current="page" {% endif
-						%}>Contact</a></li>
+				<li class="nav-item"><a href="/" {% if "/"==page.url %}aria-current="page"{% endif %}>Home</a></li>
+				<li class="nav-item"><a href="/about" {% if page.url and page.url.startsWith("/about") %}aria-current="page"{% endif %}>About</a></li>
+				<li class="nav-item"><a href="/words" {% if page.url and page.url.startsWith("/words") %}aria-current="page"{% endif %}>Words</a></li>
+				<li class="nav-item"><a href="/contact" {% if page.url and page.url.startsWith("/contact") %}aria-current="page"{% endif %}>Contact</a></li>
 			</ul>
 		</nav>
-		</div>
-		<div>
-		</div>
 	</header>
 
 	<main id="skip">
@@ -71,7 +62,7 @@
 				<span class="sep" aria-hidden="true">&middot;</span>
 				<a href="/privacy">Privacy &amp; GDPR</a>
 				<span class="sep" aria-hidden="true">&middot;</span>
-				<span>All rights reserved</span>
+				<span>Made by a human</span>
 			</p>
 
 			<ul class="footer-socials">

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -37,7 +37,7 @@
 	<a href="#skip" class="visually-hidden">Skip to main content</a>
 
 	<header>
-		<a href="/" class="home-link">@{{ metadata.title }}</a>
+		<a href="/" class="home-link"><span class="online-dot" aria-hidden="true"></span>@{{ metadata.title }}</a>
 		<nav aria-label="Primary">
 			<h2 class="visually-hidden">Top level navigation menu</h2>
 			<ul class="nav">
@@ -62,7 +62,7 @@
 				<span class="sep" aria-hidden="true">&middot;</span>
 				<a href="/privacy">Privacy &amp; GDPR</a>
 				<span class="sep" aria-hidden="true">&middot;</span>
-				<span>Made by a human</span>
+				<span>Made with love, in Berlin</span>
 			</p>
 
 			<ul class="footer-socials">

--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -1,111 +1,357 @@
 ---
 layout: layouts/base.njk
-pagination:
-data: words
-size: 1
 ---
-{# Only include the syntax highlighter CSS on blog posts, included with the CSS per-page bundle #}
 {%- css %}{% include "public/css/prism-one-light.css" %}{% endcss %}
 {%- css %}{% include "public/css/prism-diff.css" %}{%- endcss %}
-	{#- Add the heading-anchors web component to the JavaScript bundle #}
-	
+
 {% css %}
 @layer page {
 	main {
-		flex: 1;
-	}
-
-	article {
-		{# padding-top: var(--space-xl); #}
-	}
-
-	article> * + * {
-		margin-top: var(--space-xs);
-	}
-
-	article > * + h2 {
-		margin-top: var(--space-l);
-	}
-
-	article > * + h3 {
-		margin-top: var(--space-m);
-	}
-
-	article > * + h4 {
-		margin-top: var(--space-s);
-	}
-
-	h1,
-	h2,
-	h3,
-	h4,
-	h5,
-	h6 {
-		line-height: calc(1rem + .66em);
-	}
-
-	h1 {
-		font-size: calc(var(--step-4) * 2);
-		font-weight: 900;
-		text-transform: uppercase;
-		padding-top: var(--space-xs);
-		max-width: 15ch;
-	}
-
-	article {
-		font-size: var(--step-0);
-		padding-bottom: var(--space-2xl);
-		text-wrap: balance;
-	}
-
-	
-
-
-	main:has(.post) {
-		display: flex;
-		justify-content: center;
+		display: block;
 	}
 
 	.post {
+		width: 100%;
+		max-width: 72ch;
+		margin-inline: auto;
+		padding-inline: clamp(var(--space-s), 4vw, var(--space-l));
+		padding-block: var(--space-l) var(--space-3xl);
 		display: flex;
 		flex-direction: column;
-		row-gap: var(--space-s);
-		width: 65ch;
-		max-width: 100%;
+		row-gap: var(--space-l);
 	}
 
-	.meta {
+	.post-breadcrumbs {
+		font-family: var(--feature-font);
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		font-size: var(--step--2);
+		color: var(--fg-quiet);
+		margin: 0;
 		display: flex;
-		row-gap: var(--space-3xs);
-		font-size: var(--step--1);
-		color: light-dark(#333, #bbb);
-	}
-	.meta time {
-		font-size: var(--step--1);
+		flex-wrap: wrap;
+		gap: 0.6em;
 	}
 
+	.post-breadcrumbs a {
+		color: inherit;
+		text-decoration: none;
+		border-bottom: 1px solid transparent;
+	}
 
+	.post-breadcrumbs a:hover {
+		border-bottom-color: currentColor;
+		color: var(--fg);
+	}
+
+	.post-breadcrumbs .sep { opacity: 0.5; }
+
+	.post-kicker {
+		font-family: var(--feature-font);
+		text-transform: uppercase;
+		letter-spacing: 0.25em;
+		font-size: var(--step--1);
+		color: var(--fg-quiet);
+		margin: 0;
+	}
+
+	.post-header {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-s);
+	}
+
+	.post-header h1 {
+		font-family: var(--feature-font);
+		font-weight: 900;
+		text-transform: uppercase;
+		font-size: clamp(2.25rem, 6.5vw, 4.5rem);
+		line-height: 0.9;
+		letter-spacing: -0.015em;
+		color: var(--fg);
+		margin: 0;
+		text-wrap: balance;
+	}
+
+	.post-meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-xs) var(--space-s);
+		align-items: baseline;
+		font-family: var(--feature-font);
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		font-size: var(--step--1);
+		color: var(--fg-quiet);
+		margin: 0;
+	}
+
+	.post-meta .sep { opacity: 0.5; }
+
+	/* Body */
+	.post-body {
+		max-width: 62ch;
+		font-size: var(--step-0);
+		line-height: 1.65;
+		color: var(--fg);
+	}
+
+	.post-body heading-anchors { display: contents; }
+
+	.post-body p,
+	.post-body ul,
+	.post-body ol,
+	.post-body blockquote,
+	.post-body figure,
+	.post-body pre {
+		margin: 0 0 var(--space-m);
+	}
+
+	.post-body p:first-child {
+		font-size: var(--step-1);
+		line-height: 1.45;
+		color: var(--fg-muted);
+		text-wrap: balance;
+		padding-bottom: var(--space-xs);
+	}
+
+	.post-body h2 {
+		font-family: var(--feature-font);
+		font-weight: 900;
+		text-transform: uppercase;
+		font-size: var(--step-2);
+		line-height: 1;
+		letter-spacing: 0.005em;
+		margin: var(--space-l) 0 var(--space-s);
+	}
+
+	.post-body h3 {
+		font-family: var(--feature-font);
+		font-weight: 900;
+		text-transform: uppercase;
+		font-size: var(--step-1);
+		line-height: 1.05;
+		letter-spacing: 0.01em;
+		margin: var(--space-m) 0 var(--space-2xs);
+	}
+
+	.post-body h4 {
+		font-family: var(--feature-font);
+		font-weight: 900;
+		text-transform: uppercase;
+		font-size: var(--step-0);
+		letter-spacing: 0.02em;
+		margin: var(--space-m) 0 var(--space-2xs);
+	}
+
+	heading-anchors:not(:defined) :is(h2, h3, h4, h5, h6):after {
+		content: "#";
+		padding: 0;
+		opacity: 0;
+	}
+
+	.post-body code:not([class*="language-"]) {
+		background: var(--code-bg);
+		color: var(--code-fg);
+		padding: 0.1em 0.4em;
+		border-radius: 3px;
+		font-size: 0.92em;
+	}
+
+	.post-body pre {
+		border: 1px solid var(--rule-soft);
+		padding: var(--space-m);
+		overflow-x: auto;
+	}
+
+	.post-body mark,
+	.post-body .hl {
+		background-image: linear-gradient(transparent 60%, var(--accent) 60%);
+		background-color: transparent;
+		color: inherit;
+		padding: 0 0.05em;
+	}
+
+	.post-body blockquote {
+		border-left: 2px solid var(--rule);
+		padding: 0 var(--space-m);
+		color: var(--fg-muted);
+		font-style: italic;
+	}
+
+	.post-body .aside-note {
+		background: var(--highlight-bg);
+		color: var(--highlight-fg);
+		padding: var(--space-s) var(--space-m);
+		font-family: var(--feature-font);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		font-size: var(--step--1);
+		line-height: 1.35;
+	}
+
+	.post-body .callout {
+		background: var(--callout-bg);
+		color: var(--callout-fg);
+		border-radius: 4px;
+		padding: var(--space-m) var(--space-l);
+		margin-block: var(--space-m);
+	}
+
+	.post-body .callout p { margin: 0; line-height: 1.45; }
+
+	.post-body .callout.single {
+		text-align: center;
+		max-width: 50ch;
+		margin-inline: auto;
+	}
+
+	.post-body .margin-note {
+		font-size: var(--step--1);
+		line-height: 1.4;
+		color: var(--fg-subtle);
+		font-style: italic;
+		margin-block: var(--space-s);
+	}
+
+	@media (min-width: 1024px) {
+		.post-body .margin-note {
+			float: right;
+			clear: right;
+			width: 18ch;
+			margin: 0.4em -20ch 0 var(--space-m);
+		}
+	}
+
+	.post-body img,
+	.post-body picture {
+		margin-block: var(--space-m);
+	}
+
+	/* Inline "no comments" / footer callout */
+	.post-callout {
+		background: var(--callout-bg);
+		color: var(--callout-fg);
+		border-radius: 4px;
+		padding: var(--space-m) var(--space-l);
+		text-align: center;
+	}
+
+	.post-callout p { margin: 0; line-height: 1.45; }
+
+	/* Prev / next post navigation */
+	.post-footer {
+		margin-top: var(--space-xl);
+		padding-top: var(--space-m);
+		border-top: 1px solid var(--rule);
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: var(--space-m);
+	}
+
+	.post-footer > a,
+	.post-footer > span {
+		font-family: var(--feature-font);
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		font-size: var(--step--1);
+		text-decoration: none;
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3xs);
+		color: var(--fg);
+	}
+
+	.post-footer > :nth-child(2) { text-align: right; }
+
+	.post-footer .kicker {
+		font-size: var(--step--2);
+		letter-spacing: 0.15em;
+		color: var(--fg-quiet);
+	}
+
+	.post-footer .title {
+		font-size: var(--step-0);
+		text-wrap: balance;
+	}
+
+	.post-footer a:hover .title {
+		text-decoration: underline;
+		text-underline-offset: 0.2em;
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		@keyframes post-rise-in {
+			from { opacity: 0; transform: translateY(0.4rem); }
+			to   { opacity: 1; transform: translateY(0); }
+		}
+
+		.post > * {
+			animation: 650ms cubic-bezier(0.22, 1, 0.36, 1) both post-rise-in;
+		}
+
+		.post > :nth-child(1) { animation-delay:   0ms; }
+		.post > :nth-child(2) { animation-delay:  80ms; }
+		.post > :nth-child(3) { animation-delay: 160ms; }
+		.post > :nth-child(4) { animation-delay: 240ms; }
+		.post > :nth-child(5) { animation-delay: 320ms; }
+		.post > :nth-child(6) { animation-delay: 400ms; }
+	}
 }
 {% endcss %}
 
-<div class="post">
-	<div>
-	 	<h1>{% if post.postType == "TIL" %}<abbr title="Today I Learned">TIL</abbr>: {% endif %}{{ post.title }}</h1> 
-		<p class="meta"> <time class="postlist-date" datetime="{{ post.date  }}">{{ post.date | readableDate("DD") }}</time>&nbsp;· {{ post.body | markdown | wordCount }} · {{ post.body | markdown | readingTime }}</p>
+<article class="post">
+	<p class="post-breadcrumbs">
+		<a href="/words">Words</a>
+		<span class="sep" aria-hidden="true">/</span>
+		<time datetime="{{ post.date }}">{{ post.date | readableDate("dd LLL yyyy") }}</time>
+	</p>
+
+	<p class="post-kicker">&sect; {{ post.postType | postKindLabel | upper }}</p>
+
+	<header class="post-header">
+		<h1>{{ post.title }}</h1>
+		<p class="post-meta">
+			<time datetime="{{ post.date }}">{{ post.date | readableDate("dd LLL yyyy") }}</time>
+			<span class="sep" aria-hidden="true">&middot;</span>
+			<span>{{ post.body | markdown | wordCount }}</span>
+			<span class="sep" aria-hidden="true">&middot;</span>
+			<span>{{ post.body | markdown | readingTime }}</span>
+			{% if post.rssOnly %}
+				<span class="sep" aria-hidden="true">&middot;</span>
+				<span>RSS Club</span>
+			{% endif %}
+		</p>
+	</header>
+
+	<div class="post-body">
+		{{ content | safe }}
 	</div>
 
- 
-	{% if post.rssOnly %}
-	<div>
-		<aside class="notice">
-			<tt>You found a secret post!
-				<a href="https://daverupert.com/2018/01/welcome-to-rss-club/">Read more about RSS Club</a>.
-			</tt>
-		</aside>
+	<div class="post-callout">
+		<p><strong>This post doesn't support comments.</strong> If you'd like to reach out, <a href="/contact">I'd love to hear from you</a>.</p>
 	</div>
+
+	{% if pagination.previousPageItem or pagination.nextPageItem %}
+	<nav class="post-footer" aria-label="Post navigation">
+		{% if pagination.previousPageItem %}
+			<a href="/words/{{ pagination.previousPageItem.slug }}/">
+				<span class="kicker">&larr; Previous</span>
+				<span class="title">{{ pagination.previousPageItem.title }}</span>
+			</a>
+		{% else %}
+			<span></span>
+		{% endif %}
+		{% if pagination.nextPageItem %}
+			<a href="/words/{{ pagination.nextPageItem.slug }}/">
+				<span class="kicker">Next &rarr;</span>
+				<span class="title">{{ pagination.nextPageItem.title }}</span>
+			</a>
+		{% else %}
+			<span></span>
+		{% endif %}
+	</nav>
 	{% endif %}
-
-	{{ content | safe }}
-</div>
+</article>
 
 {%- js %}{% include "node_modules/@zachleat/heading-anchors/heading-anchors.js" %}{% endjs %}

--- a/content/about.njk
+++ b/content/about.njk
@@ -4,132 +4,145 @@ eleventyNavigation:
   key: "About"
   order: 3
 title: 'About'
-description: "Matt Richards — Senior Staff Product Engineer and engineering lead in Berlin. Hands-on leadership, product engineering, and building humane teams and codebases in the age of AI."
+description: "Matt Richards — Senior+ Product Engineer and engineering lead in Berlin. Hands-on leadership, product engineering, and building humane teams and codebases in the age of AI."
 ---
 {% set title ="About" %}
 {% css %}
 @layer page {
 	main {
-		display: flex;
-		justify-content: center;
-		flex: 1 0 100%;
+		display: block;
 	}
 
 	.about {
 		width: 100%;
-		max-width: 72ch;
-		padding-inline: var(--space-s);
-		padding-block: var(--space-l) var(--space-2xl);
+		max-width: 80ch;
+		margin-inline: auto;
+		padding-inline: clamp(var(--space-s), 4vw, var(--space-l));
+		padding-block: var(--space-l) var(--space-3xl);
 		display: flex;
 		flex-direction: column;
-		row-gap: var(--space-xl);
+		row-gap: var(--space-2xl);
 	}
 
+	/* Chapter opener */
 	.about-hero {
+		max-width: 52ch;
+		margin-inline: auto;
+		text-align: center;
+		padding-block: var(--space-xl);
+		border-bottom: 1px solid var(--rule);
+	}
+
+	.about-dateline {
+		font-family: var(--feature-font);
+		text-transform: uppercase;
+		font-size: var(--step--1);
+		letter-spacing: 0.22em;
+		color: var(--fg-quiet);
+		margin: 0 0 var(--space-m);
 		display: flex;
-		flex-direction: column;
-		align-items: flex-start;
-		row-gap: var(--space-m);
+		flex-wrap: wrap;
+		justify-content: center;
+		gap: 0.6em;
 	}
 
-	.portrait {
-		position: relative;
-		margin: 0;
-	}
-
-	.portrait img {
-		width: clamp(8rem, 14vw, 10rem);
-		height: clamp(8rem, 14vw, 10rem);
-		object-fit: cover;
-		border-radius: 50%;
-	}
-
-	.portrait::after {
-		content: "";
-		position: absolute;
-		inset: 0;
-		border-radius: 50%;
-		background-image: var(--grain);
-		background-size: 180px 180px;
-		opacity: 0.18;
-		mix-blend-mode: multiply;
-		pointer-events: none;
-	}
-
-	@media (prefers-color-scheme: dark) {
-		.portrait::after {
-			mix-blend-mode: screen;
-			opacity: 0.14;
-		}
-	}
-
-	.about-hero-text {
-		display: flex;
-		flex-direction: column;
-		row-gap: var(--space-s);
-	}
+	.about-dateline .sep { opacity: 0.45; }
 
 	.about-hero h1 {
-		font-size: clamp(2.5rem, 6.5vw, 4rem);
-		line-height: 0.95;
-		letter-spacing: -0.015em;
-		margin: 0;
+		font-family: var(--feature-font);
+		font-weight: 900;
+		text-transform: uppercase;
+		font-size: clamp(4rem, 12vw, 9rem);
+		line-height: 0.9;
+		letter-spacing: -0.02em;
+		margin: 0 0 var(--space-m);
+		color: var(--fg);
 	}
 
 	.about-hero .lede {
-		font-size: clamp(var(--step-1), 0.8vw + 1.05rem, var(--step-2));
-		line-height: 1.4;
-		color: light-dark(#333, #c4c4c4);
-		margin: 0;
-		text-wrap: pretty;
-		max-width: 45ch;
+		font-size: clamp(var(--step-1), 0.6vw + 1.05rem, var(--step-2));
+		line-height: 1.45;
+		color: var(--fg-muted);
+		text-wrap: balance;
+		max-width: 34ch;
+		margin: 0 auto;
 	}
 
+	/* Numbered body sections */
 	.about-section {
-		display: flex;
-		flex-direction: column;
-		row-gap: var(--space-s);
+		max-width: 64ch;
+		margin-inline: auto;
+		padding-block: var(--space-xl) 0;
+	}
+
+	.about-section + .about-section {
+		margin-top: var(--space-l);
+		padding-top: var(--space-xl);
+		border-top: 1px solid var(--rule);
 	}
 
 	.about-section h2 {
-		font-size: var(--step-2);
-		letter-spacing: 0.01em;
-		padding-top: var(--space-m);
-		margin-bottom: var(--space-3xs);
-		border-top: 1px solid light-dark(rgba(0, 0, 0, 0.12), rgba(255, 255, 255, 0.12));
+		font-family: var(--feature-font);
+		font-weight: 900;
+		text-transform: uppercase;
+		font-size: clamp(2.25rem, 4.6vw, 3.75rem);
+		line-height: 0.95;
+		letter-spacing: -0.005em;
+		color: var(--fg);
+		margin: 0 0 var(--space-m);
 	}
 
-	.about p {
-		line-height: 1.6;
+	.about-section h2 .ix {
+		display: block;
+		font-family: var(--feature-font);
+		font-weight: 400;
+		font-size: var(--step--1);
+		letter-spacing: 0.25em;
+		color: var(--fg-quiet);
+		margin-bottom: var(--space-s);
+	}
+
+	.about-section-body {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-m);
+	}
+
+	.about-section-body p {
+		margin: 0;
+		line-height: 1.65;
+		font-size: var(--step-0);
+		color: var(--fg);
 		text-wrap: pretty;
 	}
 
-	.about strong {
-		font-weight: 600;
-	}
-
-	.about a[href] {
-		text-underline-offset: 0.2em;
+	.about-section-body p:first-child {
+		font-size: var(--step-1);
+		line-height: 1.45;
 	}
 
 	.about-colophon {
+		max-width: 64ch;
+		margin: var(--space-xl) auto 0;
+		padding-top: var(--space-l);
+		border-top: 1px solid var(--rule);
 		font-size: var(--step--1);
-		color: light-dark(#555, #9a9a9a);
+		color: var(--fg-subtle);
 	}
 
 	.about-colophon h2 {
+		font-family: var(--feature-font);
+		font-weight: 900;
+		text-transform: uppercase;
 		font-size: var(--step-1);
+		letter-spacing: 0.01em;
+		color: var(--fg);
+		margin: 0 0 var(--space-s);
 	}
 
-	@media (max-width: 560px) {
-		.portrait img {
-			width: clamp(7rem, 28vw, 9rem);
-			height: clamp(7rem, 28vw, 9rem);
-		}
-
-		.about-hero h1 {
-			font-size: clamp(2rem, 10vw, 3rem);
-		}
+	.about-colophon p {
+		margin: 0 0 var(--space-s);
+		line-height: 1.55;
 	}
 
 	@media (prefers-reduced-motion: no-preference) {
@@ -143,54 +156,64 @@ description: "Matt Richards — Senior Staff Product Engineer and engineering le
 		}
 
 		.about > :nth-child(1) { animation-delay:   0ms; }
-		.about > :nth-child(2) { animation-delay:  80ms; }
-		.about > :nth-child(3) { animation-delay: 180ms; }
-		.about > :nth-child(4) { animation-delay: 280ms; }
-		.about > :nth-child(5) { animation-delay: 380ms; }
-		.about > :nth-child(6) { animation-delay: 480ms; }
+		.about > :nth-child(2) { animation-delay: 120ms; }
+		.about > :nth-child(3) { animation-delay: 220ms; }
+		.about > :nth-child(4) { animation-delay: 320ms; }
+		.about > :nth-child(5) { animation-delay: 420ms; }
+		.about > :nth-child(6) { animation-delay: 520ms; }
 	}
 }
 {% endcss %}
 
 <article class="about">
 	<header class="about-hero">
-		<figure class="portrait">
-			<img src="../public/img/1564326180592.jpeg" alt="Matt Richards, wearing shades, with beach grass in the background" width="500" height="500" loading="eager" decoding="sync" />
-		</figure>
-		<div class="about-hero-text">
-			<h1>About Matt Richards</h1>
-			<p class="lede">Hi. I'm Matt &mdash; a Senior+ Product Engineer and engineering lead based in Berlin. I build products for the web, and lead the teams that do the same.</p>
-		</div>
+		<p class="about-dateline">
+			<span>Matt Richards</span>
+			<span class="sep" aria-hidden="true">&middot;</span>
+			<span>Senior+ Product Engineer</span>
+			<span class="sep" aria-hidden="true">&middot;</span>
+			<span>Berlin</span>
+		</p>
+		<h1>Hello.</h1>
+		<p class="lede">Hi. I'm Matt &mdash; a Senior+ Product Engineer and engineering lead based in Berlin. I build products for the web, and lead the teams that do the same.</p>
 	</header>
 
 	<section class="about-section">
-		<p>Over twenty years in, I work across both product engineering and engineering leadership: technical strategy and architecture; org and roadmap design; the direct contributions that move a team's work forward.</p>
-		<p>My work sits between craft and leadership. I care about the people I build alongside as much as what gets built. I'm at home in ambitious contexts, diverse teams, and environments where the work has to matter.</p>
+		<h2><span class="ix">&sect; 01 &mdash; The work</span>The work</h2>
+		<div class="about-section-body">
+			<p>Over twenty years in, I work across both product engineering and engineering leadership: technical strategy and architecture; org and roadmap design; the direct contributions that move a team's work forward.</p>
+			<p>My work sits between craft and leadership. I care about the people I build alongside as much as what gets built. I'm at home in ambitious contexts, diverse teams, and environments where the work has to matter.</p>
+		</div>
 	</section>
 
 	<section class="about-section">
-		<h2>What I do</h2>
-		<p>Fundamentals matter to me far more than the framework of the month. SOLID principles, clean boundaries, appropriate coupling, and systems that stay coherent as they grow. The web platform comes first: HTML, CSS, the DOM and Web APIs do most of the heavy lifting before I reach for an abstraction.</p>
-		<p>On the leadership side, I set direction, bring product ambition into engineering reality, and hold teams to SMART goals over vanity metrics. Mentoring engineers through the parts of a career that actually compound: craft, judgement, and the soft skills that don't fit on a sprint board.</p>
-		<p>Mostly startups and NGOs, with a long run in global public and private health. Values-led work isn't a nice-to-have. I want what I ship to do something more useful than add a line to an investor deck. My work history is on <a href="https://linkedin.com/in/tthew">LinkedIn</a>.</p>
+		<h2><span class="ix">&sect; 02 &mdash; Craft</span>Craft</h2>
+		<div class="about-section-body">
+			<p>Fundamentals matter to me far more than the framework of the month. SOLID principles, clean boundaries, appropriate coupling, and systems that stay coherent as they grow.</p>
+			<p>The web platform comes first: HTML, CSS, the DOM and Web APIs do most of the heavy lifting before I reach for an abstraction.</p>
+			<p>On the leadership side, I set direction, bring product ambition into engineering reality, and hold teams to SMART goals over vanity metrics. Mentoring engineers through the parts of a career that actually compound: craft, judgement, and the soft skills that don't fit on a sprint board.</p>
+		</div>
 	</section>
 
 	<section class="about-section">
-		<h2>How I work</h2>
-		<p>Most of what I bring to a team at this point is judgement. Ownership matters to me: backing the team's outcome, with their autonomy left intact. Leading and interfering aren't the same thing. Stay close to the work. Stay out of the team's way.</p>
-		<p>The best leaders I've worked with held that balance without making a thing of it. I try to do the same.</p>
-		<p>Accessibility and UX as defaults. Design and systems thinking belong inside the engineering. A bias toward coherence and clarity over cleverness.</p>
+		<h2><span class="ix">&sect; 03 &mdash; How I work</span>How I work</h2>
+		<div class="about-section-body">
+			<p>Most of what I bring to a team at this point is judgement. Ownership matters to me: backing the team's outcome, with their autonomy left intact.</p>
+			<p>Leading and interfering aren't the same thing. Stay close to the work. Stay out of the team's way.</p>
+			<p>Accessibility and UX as defaults. Design and systems thinking belong inside the engineering. A bias toward coherence and clarity over cleverness.</p>
+		</div>
 	</section>
 
 	<section class="about-section">
-		<h2>The next iteration of the web</h2>
-		<p>AI is part of how I build now. I use it every day, study the research, and watch closely what it's doing to the craft &mdash; to team shape, to code quality, to how junior engineers grow up in a world where the easy work is suddenly cheap.</p>
-		<p>Keeping humans, products and codebases healthy in the age of AI is the engineering problem of the decade. I help teams avoid both failure modes: getting left behind, and letting an autocomplete quietly rot the codebase.</p>
+		<h2><span class="ix">&sect; 04 &mdash; The next iteration</span>The next iteration</h2>
+		<div class="about-section-body">
+			<p>AI is part of how I build now. I use it every day, study the research, and watch closely what it's doing to the craft &mdash; to team shape, to code quality, to how junior engineers grow up in a world where the easy work is suddenly cheap.</p>
+			<p>Keeping humans, products and codebases healthy in the age of AI is the engineering problem of the decade. I help teams avoid both failure modes: getting left behind, and letting an autocomplete quietly rot the codebase.</p>
+		</div>
 	</section>
 
-	<section class="about-section about-colophon">
+	<section class="about-colophon">
 		<h2>About this website</h2>
 		<p>Hand-made by a human (me, with a little help from <a href="https://claude.com/claude-code">Claude</a>). The front end is a static build with <a href="https://11ty.dev">11ty</a>, sourcing content from a self-hosted <a href="https://craftcms.com/">Craft CMS</a> GraphQL endpoint running on a Raspberry Pi in my apartment. A webhook triggers rebuild and redeploy whenever the data changes.</p>
-		<p><strong><a href="/privacy">This website does not track you.</a></strong></p>
 	</section>
 </article>

--- a/content/about.njk
+++ b/content/about.njk
@@ -60,12 +60,12 @@ description: "Matt Richards — Senior+ Product Engineer and engineering lead in
 	}
 
 	.about-hero .lede {
-		font-size: clamp(var(--step-1), 0.6vw + 1.05rem, var(--step-2));
-		line-height: 1.45;
+		font-size: clamp(var(--step-1), 0.5vw + 1.15rem, var(--step-2));
+		line-height: 1.55;
 		color: var(--fg-muted);
-		text-wrap: balance;
-		max-width: 34ch;
-		margin: 0 auto;
+		text-wrap: pretty;
+		max-width: 44ch;
+		margin: var(--space-s) auto 0;
 	}
 
 	/* Numbered body sections */
@@ -122,27 +122,35 @@ description: "Matt Richards — Senior+ Product Engineer and engineering lead in
 	}
 
 	.about-colophon {
-		max-width: 64ch;
-		margin: var(--space-xl) auto 0;
-		padding-top: var(--space-l);
-		border-top: 1px solid var(--rule);
-		font-size: var(--step--1);
+		max-width: none;
+		margin: var(--space-l) 0 0;
+		padding-top: var(--space-m);
+		border-top: 1px solid var(--rule-soft);
+		font-size: var(--step-0);
 		color: var(--fg-subtle);
+		text-align: center;
 	}
 
-	.about-colophon h2 {
+	.about-colophon .ix {
+		display: block;
 		font-family: var(--feature-font);
-		font-weight: 900;
+		font-weight: 400;
+		font-size: var(--step--1);
+		letter-spacing: 0.25em;
+		color: var(--fg-quiet);
+		margin-bottom: var(--space-2xs);
 		text-transform: uppercase;
-		font-size: var(--step-1);
-		letter-spacing: 0.01em;
-		color: var(--fg);
-		margin: 0 0 var(--space-s);
 	}
 
 	.about-colophon p {
-		margin: 0 0 var(--space-s);
-		line-height: 1.55;
+		margin: 0 auto;
+		max-width: 64ch;
+		line-height: 1.6;
+	}
+
+	.about-colophon a {
+		color: inherit;
+		text-underline-offset: 0.2em;
 	}
 
 	@media (prefers-reduced-motion: no-preference) {
@@ -179,7 +187,7 @@ description: "Matt Richards — Senior+ Product Engineer and engineering lead in
 	</header>
 
 	<section class="about-section">
-		<h2><span class="ix">&sect; 01 &mdash; The work</span>The work</h2>
+		<h2><span class="ix">&sect; 01 &mdash; The work</span>Two sides of the bench</h2>
 		<div class="about-section-body">
 			<p>Over twenty years in, I work across both product engineering and engineering leadership: technical strategy and architecture; org and roadmap design; the direct contributions that move a team's work forward.</p>
 			<p>My work sits between craft and leadership. I care about the people I build alongside as much as what gets built. I'm at home in ambitious contexts, diverse teams, and environments where the work has to matter.</p>
@@ -187,7 +195,7 @@ description: "Matt Richards — Senior+ Product Engineer and engineering lead in
 	</section>
 
 	<section class="about-section">
-		<h2><span class="ix">&sect; 02 &mdash; Craft</span>Craft</h2>
+		<h2><span class="ix">&sect; 02 &mdash; Craft</span>Fundamentals, first</h2>
 		<div class="about-section-body">
 			<p>Fundamentals matter to me far more than the framework of the month. SOLID principles, clean boundaries, appropriate coupling, and systems that stay coherent as they grow.</p>
 			<p>The web platform comes first: HTML, CSS, the DOM and Web APIs do most of the heavy lifting before I reach for an abstraction.</p>
@@ -196,7 +204,7 @@ description: "Matt Richards — Senior+ Product Engineer and engineering lead in
 	</section>
 
 	<section class="about-section">
-		<h2><span class="ix">&sect; 03 &mdash; How I work</span>How I work</h2>
+		<h2><span class="ix">&sect; 03 &mdash; How I work</span>Ownership, not overreach</h2>
 		<div class="about-section-body">
 			<p>Most of what I bring to a team at this point is judgement. Ownership matters to me: backing the team's outcome, with their autonomy left intact.</p>
 			<p>Leading and interfering aren't the same thing. Stay close to the work. Stay out of the team's way.</p>
@@ -205,15 +213,15 @@ description: "Matt Richards — Senior+ Product Engineer and engineering lead in
 	</section>
 
 	<section class="about-section">
-		<h2><span class="ix">&sect; 04 &mdash; The next iteration</span>The next iteration</h2>
+		<h2><span class="ix">&sect; 04 &mdash; On what's changing</span>The next iteration</h2>
 		<div class="about-section-body">
 			<p>AI is part of how I build now. I use it every day, study the research, and watch closely what it's doing to the craft &mdash; to team shape, to code quality, to how junior engineers grow up in a world where the easy work is suddenly cheap.</p>
 			<p>Keeping humans, products and codebases healthy in the age of AI is the engineering problem of the decade. I help teams avoid both failure modes: getting left behind, and letting an autocomplete quietly rot the codebase.</p>
 		</div>
 	</section>
 
-	<section class="about-colophon">
-		<h2>About this website</h2>
-		<p>Hand-made by a human (me, with a little help from <a href="https://claude.com/claude-code">Claude</a>). The front end is a static build with <a href="https://11ty.dev">11ty</a>, sourcing content from a self-hosted <a href="https://craftcms.com/">Craft CMS</a> GraphQL endpoint running on a Raspberry Pi in my apartment. A webhook triggers rebuild and redeploy whenever the data changes.</p>
-	</section>
+	<aside class="about-colophon">
+		<span class="ix">Colophon</span>
+		<p>Hand-made by a human (me, with a little help from <a href="https://claude.com/claude-code">Claude</a>). Static build with <a href="https://11ty.dev">11ty</a>, sourcing content from a self-hosted <a href="https://craftcms.com/">Craft CMS</a> on a Raspberry Pi in my apartment. A webhook rebuilds the site whenever the data changes.</p>
+	</aside>
 </article>

--- a/content/about.njk
+++ b/content/about.njk
@@ -174,7 +174,7 @@ description: "Matt Richards — Senior+ Product Engineer and engineering lead in
 			<span class="sep" aria-hidden="true">&middot;</span>
 			<span>Berlin</span>
 		</p>
-		<h1>Hello.</h1>
+		<h1>A Story.<br>In Four Parts.</h1>
 		<p class="lede">Hi. I'm Matt &mdash; a Senior+ Product Engineer and engineering lead based in Berlin. I build products for the web, and lead the teams that do the same.</p>
 	</header>
 

--- a/content/blog/_entry.njk
+++ b/content/blog/_entry.njk
@@ -6,57 +6,7 @@ pagination:
 permalink: words/{{ post.slug }}/index.html
 layout: layouts/post.njk
 eleventyExcludeFromCollections: true
-
 ---
-
-{% css %}
-@layer page {
-	main {
-		display: flex;
-		{# flex-direction: column; #}
-		col-gap: var(--space-l);
-		padding-bottom: var(--space-3xl);
-	}
-
-	article > * {
-		max-width: 65ch;
-	}
-
-	heading-anchors:not(:defined) :is(h2,h3,h4,h5,h6):after {
-		content: "#";
-		padding: 0;
-		opacity: 0;
-	}
-
-	aside {
-		display: inline-block;
-		background: light-dark(yellow, rgba(255, 255, 255, 0.2));
-		color: light-dark(var(--dark), var(--light));
-		padding: var(--space-3xs) var(--space-xs);
-	}
-
-	article p {
-		text-wrap: wrap;
-	}
-	
-	article p:first-child {
-		font-size: var(--step-1);
-		padding-bottom: var(--space-s);
-		color: light-dark(#333, #bbb);
-		text-wrap: balance;
-	}
-}
-{% endcss %}
-
-
-{% block content %}
-	<heading-anchors>
-		<article>
-    	  {{ post.body | markdown | safe }}
-		</article>
-	</heading-anchors>
-{% endblock %}
-
-<div class="callout">
-	<p><strong>This post doesn't support comments</strong> <br>(if you'd like to reach out, <a href="/contact">I'd love to hear from you!</a>)</p>
-</div>
+<heading-anchors>
+	{{ post.body | markdown | safe }}
+</heading-anchors>

--- a/content/blog/til.njk
+++ b/content/blog/til.njk
@@ -1,55 +1,14 @@
+---js
+const pagination = {
+	data: "words",
+	size: 1,
+	alias: "post",
+	before: function(items) { return items.filter(p => p.postType === 'TIL' && !p.rssOnly); }
+};
+const permalink = "til/{{ post.slug }}/index.html";
+const layout = "layouts/post.njk";
+const eleventyExcludeFromCollections = true;
 ---
-pagination:
-  data: words
-  size: 1
-  alias: post
-permalink: til/{{ post.slug }}/index.html
-layout: layouts/post.njk
-eleventyExcludeFromCollections: true
-
----
-
-{% css %}
-@layer page {
-	main {
-		display: flex;
-		col-gap: var(--space-l);
-		padding-bottom: var(--space-3xl);
-	}
-
-	article > * {
-		max-width: 65ch;
-	}
-
-	heading-anchors:not(:defined) :is(h2,h3,h4,h5,h6):after {
-		content: "#";
-		padding: 0;
-		opacity: 0;
-	}
-
-	aside {
-		display: inline-block;
-		background: light-dark(yellow, rgba(255, 255, 255, 0.2));
-		color: light-dark(var(--dark), var(--light));
-		padding: var(--space-3xs) var(--space-xs);
-	}
-
-    h1 abbr[title] {
-		border: none;
-		text-decoration: none;
-	}
-}
-{% endcss %}
-
-
-{% block content %}
-	<heading-anchors>
-		<article>
-    	  {{ post.body | markdown | safe }}
-		</article>
-	</heading-anchors>
-{% endblock %}
-
-<div class="callout">
-	<p><strong>This post doesn't support comments</strong> <br>(if you'd like to reach out, <a href="/contact">I'd love to hear from you!</a>)</p>
-</div>
+<heading-anchors>
+	{{ post.body | markdown | safe }}
+</heading-anchors>

--- a/content/contact/index.njk
+++ b/content/contact/index.njk
@@ -215,7 +215,7 @@ const eleventyNavigation = {
 <section class="contact">
 	<header class="contact-hero">
 		<h1>Say hello.</h1>
-		<p class="sub">Consulting, collaboration, or just a nice email &mdash; I usually reply within a day or two.</p>
+		<p class="sub">Consulting, collaboration, or just a nice email.<br>I usually reply within a day or two.</p>
 	</header>
 
 	<div class="contact-grid">

--- a/content/contact/index.njk
+++ b/content/contact/index.njk
@@ -1,138 +1,265 @@
 ---js
 const layout = "layouts/home.njk";
-const pagination = {
-data: "words",
-size: 10,
-before: function(data) { return data.filter(x => !x.rssOnly) }
-};
 const title = 'Get in touch';
+const description = "Get in touch with Matt Richards — consulting, collaboration, or just a nice email.";
+const eleventyNavigation = {
+	key: "Contact",
+	order: 5
+};
 ---
-
 {% css %}
 @layer page {
-    main {
-        display: flex;
-        align-items: center;
-        flex-direction: column;
-        flex: 1;
-    }
+	main {
+		display: block;
+	}
 
-    main > .contact {
-        display: flex;
-        flex-direction: column;
-        row-gap: var(--space-xl);
-        width: 80ch;
-        max-width: 100%;
-        padding: 0 var(--space-xs);
-    }
+	.contact {
+		width: 100%;
+		max-width: 80ch;
+		margin-inline: auto;
+		padding-inline: clamp(var(--space-s), 4vw, var(--space-l));
+		padding-block: var(--space-l) var(--space-3xl);
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: var(--space-xl);
+	}
 
-    form {
-        display: flex;
-        flex-direction: column;
-        row-gap: var(--space-s);
-        padding-bottom: var(--space-2xl);
-    }
+	@media (min-width: 820px) {
+		.contact { grid-template-columns: 1fr 1fr; }
+	}
 
-    form button {
-        border: none;
-        background: light-dark(#000, #fff) ;
-        color: light-dark(#eee, #111);
-        font-family: var(--feature-font);
-        padding: var(--space-3xs) var(--space-l);
-        border-radius: var(--space-m);
-        font-size: var(--step-1);
-    }
+	.contact h1 {
+		font-family: var(--feature-font);
+		font-weight: 900;
+		text-transform: uppercase;
+		font-size: clamp(3rem, 9vw, 6rem);
+		line-height: 0.9;
+		letter-spacing: -0.015em;
+		color: var(--fg);
+		margin: 0;
+	}
 
-    .field {
-        display: flex;
-        flex-direction: column;
-    }
+	.contact .sub {
+		font-size: var(--step-1);
+		color: var(--fg-muted);
+		max-width: 32ch;
+		margin: var(--space-s) 0 var(--space-m);
+		line-height: 1.4;
+	}
 
-    .field input,
-    .field textarea {
-        padding: var(--space-2xs);
-        border: 1px solid light-dark(#000, rgba(255, 255, 255, 0.2));
-        border-radius: var(--space-3xs);
-        background: light-dark(#fff, #000) ;
-        color: light-dark(#000, #fff);
-        border: 
-    }
+	.contact-channels {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+	}
 
-    .controls {
-        flex: 1;
-        display: flex;
-        justify-content: flex-end;
-    }
+	.contact-channels li {
+		padding-block: var(--space-s);
+		border-top: 1px solid var(--rule);
+		display: grid;
+		grid-template-columns: 6rem 1fr auto;
+		gap: var(--space-m);
+		align-items: baseline;
+	}
 
-    .terms {
-        display: flex;
-        column-gap: var(--space-2xs);
-        flex-direction: row;
-        align-items: center;
-        font-size: var(--step--1);
-    }
+	.contact-channels li:last-child { border-bottom: 1px solid var(--rule); }
+
+	.contact-channels .channel {
+		font-family: var(--feature-font);
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		font-size: var(--step--1);
+		color: var(--fg-quiet);
+	}
+
+	.contact-channels .handle {
+		font-family: var(--font-family-monospace);
+		font-size: var(--step--1);
+		color: var(--fg);
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.contact-channels a {
+		font-family: var(--feature-font);
+		text-transform: uppercase;
+		letter-spacing: 0.14em;
+		font-size: var(--step--2);
+		text-decoration: none;
+		border-bottom: 1px solid currentColor;
+		padding-bottom: 0.15em;
+		color: var(--fg);
+	}
+
+	.contact-channels a::after { content: "  →"; }
+	.contact-channels a:hover { opacity: 0.65; }
+
+	.contact-form {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-s);
+		padding-top: var(--space-m);
+	}
+
+	.contact-form .form-kicker {
+		font-family: var(--feature-font);
+		text-transform: uppercase;
+		letter-spacing: 0.2em;
+		font-size: var(--step--2);
+		color: var(--fg-quiet);
+		margin: 0;
+	}
+
+	.contact-form label {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+
+	.contact-form label > span {
+		font-family: var(--feature-font);
+		text-transform: uppercase;
+		font-size: var(--step--1);
+		letter-spacing: 0.1em;
+		color: var(--fg-quiet);
+	}
+
+	.contact-form input,
+	.contact-form textarea {
+		font: inherit;
+		border: 0;
+		border-bottom: 1px solid var(--rule);
+		background: transparent;
+		color: var(--fg);
+		padding: 0.2em 0;
+	}
+
+	.contact-form input:focus,
+	.contact-form textarea:focus {
+		outline: none;
+		border-bottom-color: var(--fg);
+	}
+
+	.contact-form textarea {
+		resize: vertical;
+		min-height: 6em;
+	}
+
+	.contact-form .terms {
+		flex-direction: row;
+		align-items: center;
+		gap: var(--space-2xs);
+		font-size: var(--step--1);
+	}
+
+	.contact-form .terms a { color: inherit; }
+
+	.contact-form .btn {
+		align-self: flex-start;
+		font-family: var(--feature-font);
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		font-size: var(--step--1);
+		background: var(--fg);
+		color: var(--bg);
+		border: none;
+		padding: 0.6em 1.2em;
+		cursor: pointer;
+	}
+
+	.contact-form .btn:hover {
+		opacity: 0.85;
+	}
+
+	.contact-form .muted {
+		font-size: var(--step--2);
+		color: var(--fg-quiet);
+		margin: var(--space-2xs) 0 0;
+	}
+
+	.contact-form .honeypot { position: absolute; left: -9999px; }
+
+	@media (prefers-reduced-motion: no-preference) {
+		@keyframes contact-rise-in {
+			from { opacity: 0; transform: translateY(0.4rem); }
+			to   { opacity: 1; transform: translateY(0); }
+		}
+
+		.contact > * {
+			animation: 650ms cubic-bezier(0.22, 1, 0.36, 1) both contact-rise-in;
+		}
+
+		.contact > :nth-child(1) { animation-delay:   0ms; }
+		.contact > :nth-child(2) { animation-delay: 120ms; }
+	}
 }
 {% endcss %}
 
-<div class="contact ">
-    <!--
-    <div class="callout">
-		<img src="../../public/img/119.Advertise.png" alt="404 Not Found" width="32" height="32" class="icon illustration" alt="An illustration of a man making an announcement with a megaphone."/>
-		<p><strong>I'm currently open to exploring new opportunities for 2025.</strong></p>
+<section class="contact">
+	<div>
+		<h1>Say hello.</h1>
+		<p class="sub">Consulting, collaboration, or just a nice email &mdash; I'll reply in a day or two.</p>
+		<ul class="contact-channels">
+			<li>
+				<span class="channel">Email</span>
+				<span class="handle">hallo@tthew.berlin</span>
+				<a href="mailto:hallo@tthew.berlin" rel="me">Compose</a>
+			</li>
+			<li>
+				<span class="channel">Mastodon</span>
+				<span class="handle">@tthew@hachyderm.io</span>
+				<a href="https://hachyderm.io/@tthew" rel="me">Follow</a>
+			</li>
+			<li>
+				<span class="channel">LinkedIn</span>
+				<span class="handle">/in/tthew</span>
+				<a href="https://www.linkedin.com/in/tthew/" rel="me">Connect</a>
+			</li>
+			<li>
+				<span class="channel">GitHub</span>
+				<span class="handle">/tthew</span>
+				<a href="https://github.com/tthew" rel="me">View</a>
+			</li>
+			<li>
+				<span class="channel">RSS</span>
+				<span class="handle">/feed/feed.xml</span>
+				<a href="/feed/feed.xml">Subscribe</a>
+			</li>
+		</ul>
 	</div>
-    -->
-    <div class="flow">
-    <h1>Get in touch</h1>
 
-    {# <p>I'm currently open for new opportunties.</p> #}
-    <p>If you'd like to reach out, I'd love to hear from you.</p>
-    <p>
-        Feel free to send me a message using the contact form or alternatively   <a href="mailto:hallo@tthew.berlin" rel="me">drop me an email</a>.
-    </p>
-    
-    <form netlify data-netlify-honeypot="username" method="post" name="contact" action="/contact/sent">
-        <input type="hidden" name="subject" value="[tthew.berlin] You Have A New Message!" />
-        <div class="field visually-hidden">
-            <label for="contact-form-field__username">
-                Leave this field empty if you're a human:
-            </label>
-            <input id="contact-form-field__username" name="username" class="visually-hidden" />
-        </div>
-        <div class="field">
-            <label for="contact-form-field__name">
-                Name:
-            </label>
+	<form class="contact-form" netlify data-netlify-honeypot="username" method="post" name="contact" action="/contact/sent">
+		<p class="form-kicker">Or drop a message here</p>
 
-            <input id="contact-form-field__name" placeholder="e.g. Slavoj Žižek" name="name" type="text" required />
-        </div>
-        <div class="field">
-            <label for="contact-form-field__email">
-                Email:
-            </label>
-            <input id="contact-form-field__email" placeholder="e.g. you@example.com" name="email" type="email" required />
-        </div>
-        <div class="field">
-            <label for="contact-form-field__message">
-                Message:
-            </label>
-            <textarea id="contact-form-field__message" name="message" placeholder="How can I help?" rows="10"></textarea>
-        </div>
-        <div class="field terms">
-            <input id="contact-form-field__terms" type="checkbox" name="agree_to_terms" required />
-            <label for="contact-form-field__terms">
-                I consent to the data entered into this form being processed by <a href="https://www.netlify.com/platform/core/forms/">Netlify Forms</a> and <a href="https://akismet.com/">Akismet</a> spam protection services.
-            </label>
-        </div>
+		<input type="hidden" name="subject" value="[tthew.berlin] You Have A New Message!" />
+		<input type="hidden" name="form-name" value="contact" />
 
-        
-        <input type="hidden" name="form-name" value="contact" />
-        
-        
-        <div class="controls">
-            <button type="submit">
-                Hit me up!
-            </button>
-        </div>
-    </form>
-</div>
-</div>
+		<label class="honeypot" aria-hidden="true">
+			<span>Leave empty</span>
+			<input name="username" tabindex="-1" autocomplete="off" />
+		</label>
+
+		<label>
+			<span>Your name</span>
+			<input type="text" name="name" placeholder="e.g. Slavoj &Zcaron;i&zcaron;ek" required />
+		</label>
+		<label>
+			<span>Email</span>
+			<input type="email" name="email" placeholder="e.g. you@example.com" required />
+		</label>
+		<label>
+			<span>Message</span>
+			<textarea name="message" rows="6" placeholder="How can I help?" required></textarea>
+		</label>
+
+		<label class="terms">
+			<input type="checkbox" name="agree_to_terms" required />
+			<span>I consent to this message being processed by <a href="https://www.netlify.com/platform/core/forms/">Netlify Forms</a> and <a href="https://akismet.com/">Akismet</a>.</span>
+		</label>
+
+		<button type="submit" class="btn">Send</button>
+		<p class="muted">Submitted via Netlify Forms + Akismet. This site does not track you.</p>
+	</form>
+</section>

--- a/content/contact/index.njk
+++ b/content/contact/index.njk
@@ -15,20 +15,21 @@ const eleventyNavigation = {
 
 	.contact {
 		width: 100%;
-		max-width: 80ch;
+		max-width: 90ch;
 		margin-inline: auto;
 		padding-inline: clamp(var(--space-s), 4vw, var(--space-l));
 		padding-block: var(--space-l) var(--space-3xl);
-		display: grid;
-		grid-template-columns: 1fr;
-		gap: var(--space-xl);
+		display: flex;
+		flex-direction: column;
+		row-gap: var(--space-xl);
 	}
 
-	@media (min-width: 820px) {
-		.contact { grid-template-columns: 1fr 1fr; }
+	/* Hero: full-width above both columns */
+	.contact-hero {
+		max-width: 60ch;
 	}
 
-	.contact h1 {
+	.contact-hero h1 {
 		font-family: var(--feature-font);
 		font-weight: 900;
 		text-transform: uppercase;
@@ -39,12 +40,27 @@ const eleventyNavigation = {
 		margin: 0;
 	}
 
-	.contact .sub {
+	.contact-hero .sub {
 		font-size: var(--step-1);
 		color: var(--fg-muted);
-		max-width: 32ch;
-		margin: var(--space-s) 0 var(--space-m);
-		line-height: 1.4;
+		max-width: 48ch;
+		margin: var(--space-m) 0 0;
+		line-height: 1.5;
+	}
+
+	/* Two-column block: channels on the left, form on the right. */
+	.contact-grid {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: var(--space-xl);
+		align-items: start;
+	}
+
+	@media (min-width: 820px) {
+		.contact-grid {
+			grid-template-columns: 1fr 1fr;
+			gap: clamp(var(--space-xl), 6vw, var(--space-3xl));
+		}
 	}
 
 	.contact-channels {
@@ -100,7 +116,6 @@ const eleventyNavigation = {
 		display: flex;
 		flex-direction: column;
 		gap: var(--space-s);
-		padding-top: var(--space-m);
 	}
 
 	.contact-form .form-kicker {
@@ -198,9 +213,12 @@ const eleventyNavigation = {
 {% endcss %}
 
 <section class="contact">
-	<div>
+	<header class="contact-hero">
 		<h1>Say hello.</h1>
-		<p class="sub">Consulting, collaboration, or just a nice email &mdash; I'll reply in a day or two.</p>
+		<p class="sub">Consulting, collaboration, or just a nice email &mdash; I usually reply within a day or two.</p>
+	</header>
+
+	<div class="contact-grid">
 		<ul class="contact-channels">
 			<li>
 				<span class="channel">Email</span>
@@ -228,38 +246,38 @@ const eleventyNavigation = {
 				<a href="/feed/feed.xml">Subscribe</a>
 			</li>
 		</ul>
+
+		<form class="contact-form" netlify data-netlify-honeypot="username" method="post" name="contact" action="/contact/sent">
+			<p class="form-kicker">Or drop a message here</p>
+
+			<input type="hidden" name="subject" value="[tthew.berlin] You Have A New Message!" />
+			<input type="hidden" name="form-name" value="contact" />
+
+			<label class="honeypot" aria-hidden="true">
+				<span>Leave empty</span>
+				<input name="username" tabindex="-1" autocomplete="off" />
+			</label>
+
+			<label>
+				<span>Your name</span>
+				<input type="text" name="name" placeholder="e.g. Slavoj &Zcaron;i&zcaron;ek" required />
+			</label>
+			<label>
+				<span>Email</span>
+				<input type="email" name="email" placeholder="e.g. you@example.com" required />
+			</label>
+			<label>
+				<span>Message</span>
+				<textarea name="message" rows="6" placeholder="How can I help?" required></textarea>
+			</label>
+
+			<label class="terms">
+				<input type="checkbox" name="agree_to_terms" required />
+				<span>I consent to this message being processed by <a href="https://www.netlify.com/platform/core/forms/">Netlify Forms</a> and <a href="https://akismet.com/">Akismet</a>.</span>
+			</label>
+
+			<button type="submit" class="btn">Send</button>
+			<p class="muted">Submitted via Netlify Forms + Akismet. This site does not track you.</p>
+		</form>
 	</div>
-
-	<form class="contact-form" netlify data-netlify-honeypot="username" method="post" name="contact" action="/contact/sent">
-		<p class="form-kicker">Or drop a message here</p>
-
-		<input type="hidden" name="subject" value="[tthew.berlin] You Have A New Message!" />
-		<input type="hidden" name="form-name" value="contact" />
-
-		<label class="honeypot" aria-hidden="true">
-			<span>Leave empty</span>
-			<input name="username" tabindex="-1" autocomplete="off" />
-		</label>
-
-		<label>
-			<span>Your name</span>
-			<input type="text" name="name" placeholder="e.g. Slavoj &Zcaron;i&zcaron;ek" required />
-		</label>
-		<label>
-			<span>Email</span>
-			<input type="email" name="email" placeholder="e.g. you@example.com" required />
-		</label>
-		<label>
-			<span>Message</span>
-			<textarea name="message" rows="6" placeholder="How can I help?" required></textarea>
-		</label>
-
-		<label class="terms">
-			<input type="checkbox" name="agree_to_terms" required />
-			<span>I consent to this message being processed by <a href="https://www.netlify.com/platform/core/forms/">Netlify Forms</a> and <a href="https://akismet.com/">Akismet</a>.</span>
-		</label>
-
-		<button type="submit" class="btn">Send</button>
-		<p class="muted">Submitted via Netlify Forms + Akismet. This site does not track you.</p>
-	</form>
 </section>

--- a/content/index.njk
+++ b/content/index.njk
@@ -9,7 +9,14 @@ order: 1
 {% css %}
 @layer page {
 	main {
-		display: block;
+		display: flex;
+		flex-direction: column;
+	}
+
+	@media (min-width: 721px) {
+		main {
+			justify-content: center;
+		}
 	}
 
 	.hero-wrap {
@@ -252,7 +259,11 @@ order: 1
 			grid-template-columns: 1fr;
 		}
 
-		.signal { border-right: 0; border-bottom: 1px solid var(--rule); }
+		.signal {
+			border-right: 0;
+			border-bottom: 1px solid var(--rule);
+			padding-inline: 0;
+		}
 		.signal:last-child { border-bottom: 0; }
 		.signal:first-child { padding-top: var(--space-m); }
 	}

--- a/content/index.njk
+++ b/content/index.njk
@@ -5,45 +5,44 @@ const eleventyNavigation = {
 key: "Home",
 order: 1
 };
-
-const numberOfLatestPostsToShow = 3;
 ---
 {% css %}
 @layer page {
 	main {
-		display: flex;
-		justify-content: center;
+		display: block;
 	}
 
-	.hero {
-		flex: 1;
+	.hero-wrap {
 		width: 100%;
-		display: grid;
-		place-items: center;
-		min-height: 100svh;
-		min-height: 100dvh;
-		padding-block: clamp(var(--space-l), 5svh, var(--space-2xl));
-		padding-inline: var(--space-s);
+		max-width: 80ch;
+		margin-inline: auto;
+		padding-inline: clamp(var(--space-s), 4vw, var(--space-l));
+		padding-block: clamp(var(--space-l), 6vw, var(--space-2xl)) var(--space-2xl);
+	}
+
+	@media (min-width: 1200px) {
+		.hero-wrap { max-width: 90ch; }
 	}
 
 	.hero-grid {
 		display: grid;
 		grid-template-columns: auto 1fr;
-		column-gap: clamp(var(--space-m), 5vw, var(--space-2xl));
-		align-items: start;
-		max-width: 80ch;
+		column-gap: clamp(var(--space-m), 4vw, var(--space-2xl));
+		align-items: end;
 	}
 
 	.portrait {
 		position: relative;
 		margin: 0;
+		width: fit-content;
 	}
 
 	.portrait img {
-		width: clamp(11rem, 28vw, 26rem);
-		height: clamp(11rem, 28vw, 26rem);
+		width: clamp(11rem, 22vw, 17.5rem);
+		height: clamp(11rem, 22vw, 17.5rem);
 		object-fit: cover;
 		border-radius: 50%;
+		filter: grayscale(1);
 	}
 
 	.portrait::after {
@@ -71,40 +70,84 @@ const numberOfLatestPostsToShow = 3;
 		row-gap: var(--space-s);
 	}
 
-	.display {
-		font-size: clamp(2rem, 5.8vw, 4.25rem);
-		line-height: 0.95;
-		letter-spacing: -0.01em;
-		max-width: 16ch;
+	.hero-eyebrow {
+		font-family: var(--feature-font);
+		text-transform: uppercase;
+		letter-spacing: 0.22em;
+		font-size: var(--step--2);
+		color: var(--fg-subtle);
+		display: inline-flex;
+		align-items: center;
+		gap: 0.75em;
 		margin: 0;
+	}
+
+	.hero-eyebrow::before {
+		content: "";
+		width: 2.5em;
+		height: 1px;
+		background: currentColor;
+	}
+
+	.display {
+		font-family: var(--feature-font);
+		font-weight: 900;
+		text-transform: uppercase;
+		font-size: clamp(2.5rem, 7vw, 5.25rem);
+		line-height: 0.9;
+		letter-spacing: -0.015em;
+		margin: 0;
+		text-wrap: balance;
+		color: var(--fg);
 	}
 
 	.display span {
 		display: block;
 	}
 
-	.display span + span {
-		margin-top: 0.12em;
+	.display .line-b {
+		margin-top: 0.08em;
 	}
 
 	.display em {
 		font-style: normal;
 	}
 
+	.display em.accent {
+		display: inline-block;
+		position: relative;
+		color: var(--fg);
+	}
+
+	.display em.accent::before {
+		content: "";
+		position: absolute;
+		left: -0.05em;
+		right: -0.05em;
+		top: 0.35em;
+		bottom: 0.15em;
+		background: var(--accent);
+		z-index: -1;
+	}
+
 	.lede {
 		font-size: clamp(var(--step-0), 1vw + 0.9rem, var(--step-1));
 		line-height: 1.5;
-		max-width: 42ch;
-		color: light-dark(#333, #c4c4c4);
-		margin: var(--space-2xs) 0 0 0;
+		max-width: 56ch;
+		color: var(--fg-muted);
+		margin: 0;
 		text-wrap: pretty;
 	}
 
-	.learn-more {
-		margin: var(--space-xs) 0 0 0;
+	.hero-meta {
+		margin-top: var(--space-2xs);
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-s) var(--space-m);
+		align-items: baseline;
 	}
 
-	.learn-more a {
+	.hero-meta .eyebrow-link {
 		font-family: var(--feature-font);
 		text-transform: uppercase;
 		letter-spacing: 0.15em;
@@ -115,20 +158,104 @@ const numberOfLatestPostsToShow = 3;
 		transition: opacity 0.2s ease;
 	}
 
-	.learn-more a::after {
-		content: '  →';
+	.hero-meta .eyebrow-link::after { content: "  →"; }
+	.hero-meta .eyebrow-link:hover { opacity: 0.65; }
+
+	.hero-locator {
+		font-family: var(--feature-font);
+		text-transform: uppercase;
+		letter-spacing: 0.15em;
+		font-size: var(--step--2);
+		color: var(--fg-muted);
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5em;
 	}
 
-	.learn-more a:hover {
-		opacity: 0.65;
+	.hero-locator .dot {
+		width: 0.55em;
+		height: 0.55em;
+		border-radius: 50%;
+		background: #24a148;
+		display: inline-block;
+		box-shadow: 0 0 0 3px color-mix(in oklab, #24a148 30%, transparent);
 	}
 
-	/* Narrow viewports: stack, portrait sized sensibly */
-	@media (max-width: 640px) {
+	/* Signal strip — aligned to the copy column via a mirroring grid */
+	.signal-align {
+		display: grid;
+		grid-template-columns: auto 1fr;
+		column-gap: clamp(var(--space-m), 4vw, var(--space-2xl));
+		margin-top: clamp(var(--space-xl), 6vw, var(--space-3xl));
+	}
+
+	.signal-align > :first-child {
+		/* invisible spacer matching the portrait column width */
+		width: clamp(11rem, 22vw, 17.5rem);
+	}
+
+	.signal-strip {
+		border-top: 1px solid var(--rule);
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+	}
+
+	.signal {
+		padding: var(--space-m);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3xs);
+		border-right: 1px solid var(--rule);
+	}
+	.signal:first-child { padding-left: 0; }
+	.signal:last-child  { padding-right: 0; border-right: 0; }
+
+	.signal-kicker {
+		font-family: var(--feature-font);
+		text-transform: uppercase;
+		letter-spacing: 0.18em;
+		font-size: var(--step--2);
+		color: var(--fg-quiet);
+	}
+
+	.signal-head {
+		font-family: var(--feature-font);
+		text-transform: uppercase;
+		font-size: var(--step-1);
+		line-height: 1;
+		letter-spacing: 0.01em;
+		margin: 0.1em 0 0.2em;
+		color: var(--fg);
+	}
+
+	.signal-body {
+		font-size: var(--step--1);
+		color: var(--fg-muted);
+		line-height: 1.45;
+		margin: 0;
+		max-width: 28ch;
+	}
+
+	.signal a {
+		margin-top: var(--space-2xs);
+		font-family: var(--feature-font);
+		text-transform: uppercase;
+		letter-spacing: 0.14em;
+		font-size: var(--step--2);
+		text-decoration: none;
+		border-bottom: 1px solid currentColor;
+		padding-bottom: 0.2em;
+		align-self: start;
+	}
+	.signal a::after { content: "  →"; }
+	.signal a:hover { opacity: 0.65; }
+
+	/* Narrow viewports */
+	@media (max-width: 720px) {
 		.hero-grid {
 			grid-template-columns: 1fr;
-			justify-items: start;
 			row-gap: var(--space-m);
+			align-items: start;
 		}
 
 		.portrait img {
@@ -137,37 +264,21 @@ const numberOfLatestPostsToShow = 3;
 		}
 
 		.display {
-			font-size: clamp(1.8rem, 8.5vw, 2.8rem);
-			max-width: none;
-		}
-	}
-
-	/* Short viewports (horizontal only): compress vertical rhythm */
-	@media (max-height: 700px) and (min-width: 641px) {
-		.hero {
-			padding-block: var(--space-m);
+			font-size: clamp(2rem, 10vw, 3rem);
 		}
 
-		.hero-content {
-			row-gap: var(--space-2xs);
+		.signal-align {
+			display: block;
+		}
+		.signal-align > :first-child { display: none; }
+
+		.signal-strip {
+			grid-template-columns: 1fr;
 		}
 
-		.display {
-			font-size: clamp(1.65rem, 4.5vw, 2.5rem);
-		}
-
-		.portrait img {
-			width: clamp(7rem, 22vh, 14rem);
-			height: clamp(7rem, 22vh, 14rem);
-		}
-	}
-
-	/* Wider viewports: loosen */
-	@media (min-width: 1200px) {
-		.hero-grid {
-			column-gap: var(--space-3xl);
-			max-width: 90ch;
-		}
+		.signal { border-right: 0; border-bottom: 1px solid var(--rule); }
+		.signal:last-child { border-bottom: 0; }
+		.signal:first-child { padding-top: var(--space-m); }
 	}
 
 	@media (prefers-reduced-motion: no-preference) {
@@ -177,31 +288,63 @@ const numberOfLatestPostsToShow = 3;
 		}
 
 		.portrait,
-		.hero-content > * {
+		.hero-content > *,
+		.signal {
 			animation: 650ms cubic-bezier(0.22, 1, 0.36, 1) both rise-in;
 		}
 
 		.portrait                     { animation-delay:   0ms; }
 		.hero-content > :nth-child(1) { animation-delay:  80ms; }
-		.hero-content > :nth-child(2) { animation-delay: 180ms; }
-		.hero-content > :nth-child(3) { animation-delay: 320ms; }
-		.hero-content > :nth-child(4) { animation-delay: 440ms; }
+		.hero-content > :nth-child(2) { animation-delay: 160ms; }
+		.hero-content > :nth-child(3) { animation-delay: 240ms; }
+		.hero-content > :nth-child(4) { animation-delay: 320ms; }
+		.signal:nth-child(1) { animation-delay: 420ms; }
+		.signal:nth-child(2) { animation-delay: 500ms; }
+		.signal:nth-child(3) { animation-delay: 580ms; }
 	}
 }
 {% endcss %}
 
-<section class="hero" aria-labelledby="hero-heading">
+<section class="hero-wrap" aria-labelledby="hero-heading">
 	<div class="hero-grid">
 		<figure class="portrait">
 			<img src="../public/img/1564326180592.jpeg" alt="" width="500" height="500" loading="eager" decoding="sync" fetchpriority="high" />
 		</figure>
 		<div class="hero-content">
+			<p class="hero-eyebrow">Matt Richards &middot; Berlin &middot; {% year %}</p>
 			<h1 id="hero-heading" class="display">
-				<span>Hi. I'm Matt.</span>
-				<span>Engineering lead. Building for the<br><em>next</em> iteration of the web.</span>
+				<span class="line-a">Hi. I'm Matt.</span>
+				<span class="line-b">Engineering lead. Building for the <em class="accent">next</em> iteration of the web.</span>
 			</h1>
 			<p class="lede">I do product engineering and management. I build for the web, and lead teams that do the same. I know how to keep humans, products, and codebases healthy in the age of AI.</p>
-			<p class="learn-more"><a href="/about">More about me</a></p>
+			<div class="hero-meta">
+				<a class="eyebrow-link" href="/about">More about me</a>
+				<span class="hero-locator"><span class="dot" aria-hidden="true"></span>Currently open to new work</span>
+			</div>
+		</div>
+	</div>
+
+	<div class="signal-align">
+		<div aria-hidden="true"></div>
+		<div class="signal-strip">
+			<div class="signal">
+				<span class="signal-kicker">What I do</span>
+				<h2 class="signal-head">Product engineering</h2>
+				<p class="signal-body">Platform-first. HTML, CSS and the DOM before any framework. Coherent systems that outlive the hype cycle.</p>
+				<a href="/about">Read more</a>
+			</div>
+			<div class="signal">
+				<span class="signal-kicker">How I lead</span>
+				<h2 class="signal-head">Trust, don't meddle</h2>
+				<p class="signal-body">Backing the team's outcome with their autonomy left intact. Leading and interfering aren't the same thing.</p>
+				<a href="/about">Read more</a>
+			</div>
+			<div class="signal">
+				<span class="signal-kicker">Writing</span>
+				<h2 class="signal-head">Words &amp; TIL</h2>
+				<p class="signal-body">Notes on craft, leadership, and keeping codebases humane in the age of autocomplete.</p>
+				<a href="/words">Read the archive</a>
+			</div>
 		</div>
 	</div>
 </section>

--- a/content/index.njk
+++ b/content/index.njk
@@ -17,7 +17,7 @@ order: 1
 		max-width: 80ch;
 		margin-inline: auto;
 		padding-inline: clamp(var(--space-s), 4vw, var(--space-l));
-		padding-block: clamp(var(--space-l), 6vw, var(--space-2xl)) var(--space-2xl);
+		padding-block: clamp(var(--space-l), 6vw, var(--space-xl)) var(--space-l);
 	}
 
 	@media (min-width: 1200px) {
@@ -28,7 +28,7 @@ order: 1
 		display: grid;
 		grid-template-columns: auto 1fr;
 		column-gap: clamp(var(--space-m), 4vw, var(--space-2xl));
-		align-items: end;
+		align-items: start;
 	}
 
 	.portrait {
@@ -172,29 +172,10 @@ order: 1
 		gap: 0.5em;
 	}
 
-	.hero-locator .dot {
-		width: 0.55em;
-		height: 0.55em;
-		border-radius: 50%;
-		background: #24a148;
-		display: inline-block;
-		box-shadow: 0 0 0 3px color-mix(in oklab, #24a148 30%, transparent);
-	}
 
-	/* Signal strip — aligned to the copy column via a mirroring grid */
-	.signal-align {
-		display: grid;
-		grid-template-columns: auto 1fr;
-		column-gap: clamp(var(--space-m), 4vw, var(--space-2xl));
-		margin-top: clamp(var(--space-xl), 6vw, var(--space-3xl));
-	}
-
-	.signal-align > :first-child {
-		/* invisible spacer matching the portrait column width */
-		width: clamp(11rem, 22vw, 17.5rem);
-	}
-
+	/* Signal strip — full hero-wrap width, three equal cells */
 	.signal-strip {
+		margin-top: clamp(var(--space-xl), 6vw, var(--space-3xl));
 		border-top: 1px solid var(--rule);
 		display: grid;
 		grid-template-columns: repeat(3, 1fr);
@@ -267,11 +248,6 @@ order: 1
 			font-size: clamp(2rem, 10vw, 3rem);
 		}
 
-		.signal-align {
-			display: block;
-		}
-		.signal-align > :first-child { display: none; }
-
 		.signal-strip {
 			grid-template-columns: 1fr;
 		}
@@ -311,40 +287,36 @@ order: 1
 			<img src="../public/img/1564326180592.jpeg" alt="" width="500" height="500" loading="eager" decoding="sync" fetchpriority="high" />
 		</figure>
 		<div class="hero-content">
-			<p class="hero-eyebrow">Matt Richards &middot; Berlin &middot; {% year %}</p>
 			<h1 id="hero-heading" class="display">
 				<span class="line-a">Hi. I'm Matt.</span>
 				<span class="line-b">Engineering lead. Building for the <em class="accent">next</em> iteration of the web.</span>
 			</h1>
-			<p class="lede">I do product engineering and management. I build for the web, and lead teams that do the same. I know how to keep humans, products, and codebases healthy in the age of AI.</p>
+			<p class="lede">I do product engineering and management. I build for the web, and lead teams that do the same. I know how to keep humans, products, and codebases healthy in times like these.</p>
 			<div class="hero-meta">
 				<a class="eyebrow-link" href="/about">More about me</a>
-				<span class="hero-locator"><span class="dot" aria-hidden="true"></span>Currently open to new work</span>
+				<span class="hero-locator"><span class="online-dot" aria-hidden="true"></span>Currently open to new work</span>
 			</div>
 		</div>
 	</div>
 
-	<div class="signal-align">
-		<div aria-hidden="true"></div>
-		<div class="signal-strip">
-			<div class="signal">
-				<span class="signal-kicker">What I do</span>
-				<h2 class="signal-head">Product engineering</h2>
-				<p class="signal-body">Platform-first. HTML, CSS and the DOM before any framework. Coherent systems that outlive the hype cycle.</p>
-				<a href="/about">Read more</a>
-			</div>
-			<div class="signal">
-				<span class="signal-kicker">How I lead</span>
-				<h2 class="signal-head">Trust, don't meddle</h2>
-				<p class="signal-body">Backing the team's outcome with their autonomy left intact. Leading and interfering aren't the same thing.</p>
-				<a href="/about">Read more</a>
-			</div>
-			<div class="signal">
-				<span class="signal-kicker">Writing</span>
-				<h2 class="signal-head">Words &amp; TIL</h2>
-				<p class="signal-body">Notes on craft, leadership, and keeping codebases humane in the age of autocomplete.</p>
-				<a href="/words">Read the archive</a>
-			</div>
+	<div class="signal-strip">
+		<div class="signal">
+			<span class="signal-kicker">What I do</span>
+			<h2 class="signal-head">Product engineering</h2>
+			<p class="signal-body">Platform-first. HTML, CSS and the DOM before any framework. Coherent systems that outlive the hype cycle.</p>
+			<a href="/about">Read more</a>
+		</div>
+		<div class="signal">
+			<span class="signal-kicker">How I lead</span>
+			<h2 class="signal-head">Trust, don't meddle</h2>
+			<p class="signal-body">Backing the team's outcome with their autonomy left intact. Leading and interfering aren't the same thing.</p>
+			<a href="/about">Read more</a>
+		</div>
+		<div class="signal">
+			<span class="signal-kicker">Writing</span>
+			<h2 class="signal-head">Words &amp; TIL</h2>
+			<p class="signal-body">Notes on craft, leadership, and keeping codebases humane in the age of autocomplete.</p>
+			<a href="/words">Read the archive</a>
 		</div>
 	</div>
 </section>

--- a/content/words.njk
+++ b/content/words.njk
@@ -191,7 +191,7 @@ const eleventyNavigation = {
 
 <section class="words">
 	<header class="words-head">
-		<h1>Words &amp; TIL</h1>
+		<h1>Words</h1>
 		<p class="words-sub">Essays, notes and things learned. On product engineering, leadership, and keeping codebases humane.</p>
 	</header>
 

--- a/content/words.njk
+++ b/content/words.njk
@@ -1,50 +1,224 @@
 ---js
 const layout = "layouts/home.njk";
-const pagination = {
-  data: "words",
-  size: 10,
-  before: function(data) { return data.filter(x => !x.rssOnly) }
-};
 const title = 'Words';
+const description = "Essays, TIL and notes from Matt Richards — on product engineering, engineering leadership, and keeping codebases humane in the age of AI.";
+const eleventyNavigation = {
+	key: "Words",
+	order: 4
+};
 ---
-
 {% css %}
 @layer page {
 	main {
-		display: flex;
-		justify-content: center;
-		min-height: 100vh;
-		flex: 1;
-		padding-bottom: var(--space-xl);
-	}
-
-	main > * {
-		width: 80ch;
-		max-width: 100%;
+		display: block;
 	}
 
 	.words {
-		display: flex;
-		flex-direction: column;
-		row-gap: var(--space-l);
+		width: 100%;
+		max-width: 80ch;
+		margin-inline: auto;
+		padding-inline: clamp(var(--space-s), 4vw, var(--space-l));
+		padding-block: var(--space-l) var(--space-3xl);
 	}
 
-	.pagination {
+	.words-head {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		align-items: end;
+		gap: var(--space-m);
+		padding-bottom: var(--space-l);
+		border-bottom: 1px solid var(--rule);
+	}
+
+	.words-head h1 {
+		font-family: var(--feature-font);
+		font-weight: 900;
+		text-transform: uppercase;
+		font-size: clamp(3rem, 9vw, 6rem);
+		line-height: 0.9;
+		letter-spacing: -0.015em;
+		margin: 0;
+		color: var(--fg);
+	}
+
+	.words-head .words-sub {
+		font-size: var(--step-0);
+		color: var(--fg-muted);
+		max-width: 36ch;
+		margin: 0;
+		text-align: right;
+		line-height: 1.45;
+	}
+
+	.year-group { margin-top: var(--space-xl); }
+
+	.year-label {
+		font-family: var(--feature-font);
+		font-weight: 900;
+		text-transform: uppercase;
+		font-size: var(--step-4);
+		letter-spacing: -0.01em;
+		color: var(--fg);
+		margin: 0 0 var(--space-s);
+		padding-bottom: var(--space-2xs);
+		position: relative;
+	}
+
+	.year-label::after {
+		content: "";
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		height: 1px;
+		background: var(--rule);
+	}
+
+	.postlist {
 		list-style: none;
-		margin: none;
+		margin: 0;
+		padding: 0;
 		display: flex;
-		justify-content: space-between;
+		flex-direction: column;
+	}
+
+	.postlist-item {
+		display: grid;
+		grid-template-columns: 6rem 1fr auto;
+		gap: var(--space-m);
+		padding-block: var(--space-m);
+		border-bottom: 1px solid var(--rule-soft);
+		align-items: baseline;
+	}
+
+	.postlist-item:last-child { border-bottom: 0; }
+
+	.postlist-date {
+		font-family: var(--feature-font);
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		font-size: var(--step--1);
+		color: var(--fg-quiet);
+		white-space: nowrap;
+	}
+
+	.postlist-main {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3xs);
+		min-width: 0;
+	}
+
+	.postlist-link {
+		font-family: var(--feature-font);
+		font-weight: 900;
+		text-transform: uppercase;
+		font-size: var(--step-2);
+		line-height: 1;
+		letter-spacing: 0.005em;
+		color: var(--fg);
+		text-decoration: none;
+	}
+
+	.postlist-link:hover {
+		text-decoration: underline;
+		text-underline-offset: 0.15em;
+	}
+
+	.postlist-blurb {
+		color: var(--fg-muted);
+		font-size: var(--step-0);
+		line-height: 1.45;
+		margin: var(--space-3xs) 0 0;
+		max-width: 60ch;
+	}
+
+	.postlist-meta {
+		font-family: var(--feature-font);
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		font-size: var(--step--2);
+		color: var(--fg-quiet);
+		text-align: right;
+		white-space: nowrap;
+	}
+
+	.postlist-meta .kind-tag {
+		display: inline-block;
+		padding: 0.2em 0.5em;
+		border: 1px solid currentColor;
+		letter-spacing: 0.12em;
+		margin-bottom: 0.4em;
+	}
+
+	.words-empty {
+		padding-block: var(--space-xl);
+		text-align: center;
+		color: var(--fg-subtle);
+		font-size: var(--step-0);
+	}
+
+	@media (max-width: 720px) {
+		.words-head {
+			grid-template-columns: 1fr;
+		}
+		.words-head .words-sub { text-align: left; }
+
+		.postlist-item {
+			grid-template-columns: 1fr;
+			gap: var(--space-3xs);
+		}
+		.postlist-meta { text-align: left; }
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		@keyframes words-rise-in {
+			from { opacity: 0; transform: translateY(0.4rem); }
+			to   { opacity: 1; transform: translateY(0); }
+		}
+
+		.words > * {
+			animation: 650ms cubic-bezier(0.22, 1, 0.36, 1) both words-rise-in;
+		}
+
+		.words > :nth-child(1) { animation-delay:   0ms; }
+		.words > :nth-child(2) { animation-delay: 100ms; }
+		.words > :nth-child(3) { animation-delay: 180ms; }
+		.words > :nth-child(4) { animation-delay: 260ms; }
 	}
 }
 {% endcss %}
 
-<div class="words">
-<h1>Words</h1>
+<section class="words">
+	<header class="words-head">
+		<h1>Words &amp; TIL</h1>
+		<p class="words-sub">Essays, notes and things learned. On product engineering, leadership, and keeping codebases humane.</p>
+	</header>
 
-{% set postslist = pagination.items | webWords | reverse  %}
-{% include "postslist.njk" %}
-<ol class="pagination">
-  {% if pagination.href.previous %}<li><a href="{{ pagination.href.previous }}">Previous Page</a></li>{% endif %}
-  {% if pagination.href.next %}<li><a href="{{ pagination.href.next }}">Next Page</a></li>{% endif %}
-</ol>
-</div>
+	{% set grouped = words | allWebWords | reverse | groupByYear %}
+	{% if grouped.length == 0 %}
+		<p class="words-empty">Nothing here yet. Check back soon.</p>
+	{% else %}
+		{% for group in grouped %}
+			<div class="year-group">
+				<h2 class="year-label">{{ group.year }}</h2>
+				<ol class="postlist">
+					{% for post in group.posts %}
+						{% set renderedBody = post.body | markdown %}
+						<li class="postlist-item">
+							<time class="postlist-date" datetime="{{ post.date }}">{{ post.date | readableDate("dd LLL") }}</time>
+							<div class="postlist-main">
+								<a class="postlist-link" href="/words/{{ post.slug }}/">{{ post.title }}</a>
+								<p class="postlist-blurb">{{ renderedBody | blurb }}</p>
+							</div>
+							<div class="postlist-meta">
+								{% if post.postType and post.postType != 'Article' %}<span class="kind-tag">{{ post.postType | postKindLabel }}</span><br>{% endif %}
+								<span>{{ renderedBody | readingTime }}</span>
+							</div>
+						</li>
+					{% endfor %}
+				</ol>
+			</div>
+		{% endfor %}
+	{% endif %}
+</section>

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -176,12 +176,14 @@
 		--highlight-bg: light-dark(yellow, rgba(255, 255, 255, 0.2));
 		--highlight-fg: light-dark(var(--dark), var(--light));
 
-		/* Accent swatches. Default = peach; swap via [data-accent] on <html>. */
+		/* Accent swatches. Default = peach; swap via [data-accent] on <html>.
+		   Dark-mode variants are translucent so the accent reads as a
+		   highlight overlay rather than a jarring solid against the ink. */
 		--accent-yellow: #ffd900;
 		--accent-peach: #ffb78a;
 		--accent-mint: #a6ecc7;
 		--accent-lilac: #cbb3ff;
-		--accent: var(--accent-peach);
+		--accent: light-dark(var(--accent-peach), rgba(255, 190, 120, 0.28));
 
 		--font-family: -apple-system, system-ui, sans-serif;
 		--font-family-monospace: Consolas, Menlo, Monaco, Andale Mono WT,
@@ -194,10 +196,10 @@
 		--header-height: 70px;
 	}
 
-	[data-accent="yellow"] { --accent: var(--accent-yellow); }
-	[data-accent="peach"]  { --accent: var(--accent-peach); }
-	[data-accent="mint"]   { --accent: var(--accent-mint); }
-	[data-accent="lilac"]  { --accent: var(--accent-lilac); }
+	[data-accent="yellow"] { --accent: light-dark(var(--accent-yellow), rgba(255, 255, 255, 0.2)); }
+	[data-accent="peach"]  { --accent: light-dark(var(--accent-peach),  rgba(255, 190, 120, 0.28)); }
+	[data-accent="mint"]   { --accent: light-dark(var(--accent-mint),   rgba(120, 220, 170, 0.28)); }
+	[data-accent="lilac"]  { --accent: light-dark(var(--accent-lilac),  rgba(200, 180, 255, 0.30)); }
 }
 
 @layer main {
@@ -570,8 +572,9 @@
 	}
 
 
+	/* Sticky footer: main grows to push footer to the viewport bottom. */
 	main {
-		display: flex;
+		flex: 1 0 auto;
 	}
 
 	.container {

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -149,14 +149,39 @@
 
 		--dark: #111;
 		--light: #fff;
-		
-		color-scheme: light dark;
-		
-		--background: light-dark(#faf9f6, var(--dark));
-		--text: light-dark(var(--dark),  hwb(213 78% 16% / 1));
+		--paper: #faf9f6;
+		--ink-blue: hwb(213 78% 16% / 1);
 
-		--callout-bg: light-dark(rgba(0,0,0,0.02),rgba(255,255,255, 0.03));
+		color-scheme: light dark;
+
+		/* Semantic colour tokens — use these in new rules. */
+		--bg: light-dark(var(--paper), var(--dark));
+		--fg: light-dark(var(--dark), var(--ink-blue));
+		--fg-muted: light-dark(#333, #c4c4c4);
+		--fg-subtle: light-dark(#555, #9a9a9a);
+		--fg-quiet: light-dark(#666, #9a9a9a);
+		--rule: light-dark(rgba(0, 0, 0, 0.12), rgba(255, 255, 255, 0.12));
+		--rule-soft: light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.1));
+
+		/* Back-compat aliases for pre-redesign rules. */
+		--background: var(--bg);
+		--text: var(--fg);
+
+		--callout-bg: light-dark(rgba(0,0,0,0.02), rgba(255,255,255, 0.03));
 		--callout-fg: light-dark(#555, hsl(230, 1%, 98%));
+
+		--code-bg: hsl(230, 1%, 98%);
+		--code-fg: #555;
+
+		--highlight-bg: light-dark(yellow, rgba(255, 255, 255, 0.2));
+		--highlight-fg: light-dark(var(--dark), var(--light));
+
+		/* Accent swatches. Default = peach; swap via [data-accent] on <html>. */
+		--accent-yellow: #ffd900;
+		--accent-peach: #ffb78a;
+		--accent-mint: #a6ecc7;
+		--accent-lilac: #cbb3ff;
+		--accent: var(--accent-peach);
 
 		--font-family: -apple-system, system-ui, sans-serif;
 		--font-family-monospace: Consolas, Menlo, Monaco, Andale Mono WT,
@@ -165,9 +190,14 @@
 			Courier, monospace;
 
 		--syntax-tab-size: 2;
-		
+
 		--header-height: 70px;
 	}
+
+	[data-accent="yellow"] { --accent: var(--accent-yellow); }
+	[data-accent="peach"]  { --accent: var(--accent-peach); }
+	[data-accent="mint"]   { --accent: var(--accent-mint); }
+	[data-accent="lilac"]  { --accent: var(--accent-lilac); }
 }
 
 @layer main {
@@ -295,11 +325,6 @@
 		margin-top: 0;
 	}
 
-	body > header {
-		display: flex;
-		flex-direction: column;
-	}
-
 	table {
 		margin: 1em 0;
 	}
@@ -342,22 +367,30 @@
 		padding: 1rem;
 	}
 
-	/* Header */
+	/* Site header — sticky, translucent, 1px bottom hairline */
 	body > header {
-		padding: 0 var(--space-s);
-	}
-	body > header > :first-child {
+		position: sticky;
+		top: 0;
+		z-index: 50;
 		display: flex;
 		flex-wrap: wrap;
 		align-items: center;
 		justify-content: space-between;
-		/* padding: 0 var(--space-s);	 */
-		color: light-dark(#333, #fff);
+		column-gap: var(--space-m);
+		padding-inline: clamp(var(--space-s), 3vw, var(--space-l));
 		height: var(--header-height);
+		background: color-mix(in oklab, var(--bg) 88%, transparent);
+		backdrop-filter: saturate(1.1);
+		border-bottom: 1px solid var(--rule);
+		color: light-dark(#333, #fff);
+		font-family: var(--feature-font);
+		text-transform: uppercase;
 	}
 
 	.home-link {
 		font-weight: 700;
+		font-size: var(--step-1);
+		letter-spacing: 0.02em;
 	}
 
 	.home-link:link:not(:hover) {
@@ -370,12 +403,18 @@
 		padding: 0;
 		margin: 0;
 		list-style: none;
-		column-gap: var(--space-s);
+		column-gap: clamp(var(--space-s), 2vw, var(--space-m));
 	}
 
 	.nav-item {
 		display: inline-block;
 		text-align: right;
+	}
+
+	.nav-item a {
+		font-size: var(--step--1);
+		letter-spacing: 0.08em;
+		padding: 0.25em 0;
 	}
 
 	.nav-item a[href]:not(:hover) {
@@ -388,6 +427,8 @@
 
 	.nav a[href][aria-current="page"] {
 		text-decoration: underline;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 0.4em;
 	}
 
 	/* Posts list */
@@ -409,11 +450,6 @@
 		text-underline-offset: 0;
 		text-decoration-thickness: 1px;
 		font-family: var(--feature-font);
-	}
-
-	body > header {
-		font-family: var(--feature-font);
-		text-transform: uppercase;
 	}
 
 	.flow > * + * {

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -391,10 +391,52 @@
 		font-weight: 700;
 		font-size: var(--step-1);
 		letter-spacing: 0.02em;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.45em;
 	}
 
 	.home-link:link:not(:hover) {
 		text-decoration: none;
+	}
+
+	/* Reusable "online" indicator — used in the header @tthew brand
+	   and on the home hero's "Currently open to new work" locator. */
+	.online-dot {
+		display: inline-block;
+		width: 0.55em;
+		height: 0.55em;
+		border-radius: 50%;
+		background: #24a148;
+		flex-shrink: 0;
+		position: relative;
+	}
+
+	.online-dot::before,
+	.online-dot::after {
+		content: "";
+		position: absolute;
+		inset: 0;
+		border-radius: 50%;
+		background: inherit;
+		opacity: 0;
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		@keyframes online-dot-pulse {
+			0%   { transform: scale(1);   opacity: 0.55; }
+			15%  { transform: scale(2.4); opacity: 0;    }
+			100% { transform: scale(2.4); opacity: 0;    }
+		}
+
+		.online-dot::before {
+			animation: online-dot-pulse 5s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+		}
+
+		.online-dot::after {
+			animation: online-dot-pulse 5s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+			animation-delay: 2.5s;
+		}
 	}
 
 	/* Nav */
@@ -458,16 +500,13 @@
 
 
 	footer {
-		display: flex;
-		flex-direction: column;
-		row-gap: var(--space-s);
 		width: 100%;
-		margin-top: var(--space-3xl);
-		padding-block: var(--space-xl) var(--space-l);
-		padding-inline: clamp(var(--space-s), 4vw, var(--space-2xl));
-		color: light-dark(#666, #9a9a9a);
+		margin-top: var(--space-l);
+		padding-block: var(--space-m);
+		padding-inline: clamp(var(--space-s), 4vw, var(--space-l));
+		color: var(--fg-quiet);
 		background: transparent;
-		border-top: 1px solid light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.1));
+		border-top: 1px solid var(--rule);
 	}
 
 	.footer-bottom {


### PR DESCRIPTION
## Summary

Applies the handoff at [`design_handoff_tthew_website/`](../tree/design-handoff/design_handoff_tthew_website) across the whole site — tokens, chrome, and five screens. Ported to 11ty + vanilla CSS (no React, no build step, matching the project's platform-first philosophy).

### Phases (one commit each)

- **chrome + home** — expand the token set (semantic `--fg-*`, `--rule*`, `--paper`, `--ink-blue`, `--highlight-*`, plus a `[data-accent]` swatch system with a peach default), flatten the site header into a sticky single-row chrome, and add the home's eyebrow + "next" accent + signal strip.
- **about** — chapter-opener hero ("A Story. In Four Parts.") plus four `§ 01–04` numbered sections with thematic eyebrows.
- **words + post** — year-grouped Words index with mixed post kinds (Essay / TIL / Note), an editorial post layout with kicker + display title + meta row + styled callouts / `<mark>` highlights / margin notes + prev/next footer wired from `pagination.previousPageItem/.nextPageItem`.
- **contact** — two-column editorial layout: "Say hello." display title + channels list (Email / Mastodon / LinkedIn / GitHub / RSS) on the left, existing Netlify form restyled in the editorial idiom on the right.
- **polish pass** — sticky footer (main flex-grows to anchor the footer at viewport bottom on short-content pages), home content vertically centred on wider viewports, dark-mode accent highlights converted to translucent overlays via `light-dark()`, signal-strip mobile card alignment fix, and about-page colophon knocked back to a centred signoff.

## New filters

- `allWebWords` — public-web filter that keeps Articles + TIL + Notes (only `rssOnly` is excluded).
- `groupByYear` — groups posts into `[{year, posts}, …]` with years descending.
- `postKindLabel` — maps `postType` to display label (Article → Essay; passthrough for TIL/Note).
- Fixed the broken `TIL` filter (was checking `pageType` instead of `postType`).

## Accessibility / preferences

- `prefers-color-scheme` — every token uses `light-dark()`, no JS toggle. Verified with Playwright `colorScheme: dark`.
- `prefers-reduced-motion` — all page-level rise-in animations and the online-dot pulse are guarded by `@media (prefers-reduced-motion: no-preference)`, plus a site-wide `@media (prefers-reduced-motion) { * { animation: none !important } }` fallback. Verified with Playwright `reducedMotion: reduce`.

## Local limitations

Local dev has no `API_URL/API_TOKEN`, so `_data/words.js` returns `[]`. Consequence:

- `/words/` renders correctly in its empty state (header + "Nothing here yet…") — full year-grouped index only appears with real data.
- Individual post URLs (`/words/<slug>/`) and the Netlify contact flow aren't testable locally.

Full review of Words index (with posts), individual Post pages, and Contact form submission should happen in the **Netlify PR preview** once the build completes.

## Test plan

- [ ] `npm run build` completes without errors
- [ ] `/` — hero, signal strip, peach accent on "next", vertical centering at ≥721px, stacked single-col below
- [ ] `/about/` — chapter-opener hero, four `§ 01–§ 04` sections with swapped eyebrow/title treatment, centred colophon signoff
- [ ] `/words/` (Netlify preview) — year groups, kind labels, blurb + reading-time per row
- [ ] `/words/<slug>/` (Netlify preview) — kicker, display title, meta row, body typography, prev/next footer wired correctly
- [ ] `/contact/` — two-column on desktop, stacked on mobile, channel links + Netlify form
- [ ] Dark mode (`prefers-color-scheme: dark`) across every route
- [ ] Reduced motion (`prefers-reduced-motion: reduce`) disables rise-in and the online-dot pulse
- [ ] Footer anchors to viewport bottom on short-content pages (e.g. `/words/` empty state)
- [ ] Header `aria-current="page"` underline lands on the correct item on each route

🤖 Generated with [Claude Code](https://claude.com/claude-code)