### PR TITLE
refactor(landing): Related services uses shared services-grid styling

### DIFF
--- a/_includes/css/landing.css
+++ b/_includes/css/landing.css
@@ -269,71 +269,8 @@ main { display: block; }
 	text-underline-offset: 0.2em;
 }
 
-/* Related services strip (cross-links to sibling landing pages).
-   Spans the full .landing width as a 3-card row. */
-.landing-related {
-	padding-top: var(--space-l);
-	border-top: 1px solid var(--rule);
-}
-
-.landing-related h2 {
-	font-family: var(--feature-font);
-	font-weight: 400;
-	text-transform: uppercase;
-	font-size: var(--step--1);
-	letter-spacing: 0.25em;
-	color: var(--fg-quiet);
-	margin: 0 0 var(--space-m);
-}
-
-.landing-related-list {
-	list-style: none;
-	margin: 0;
-	padding: 0;
-	border-top: 1px solid var(--rule);
-	display: grid;
-	grid-template-columns: repeat(3, 1fr);
-}
-
-.landing-related-list li {
-	padding: var(--space-m);
-	display: flex;
-	flex-direction: column;
-	gap: var(--space-3xs);
-	border-right: 1px solid var(--rule);
-	line-height: 1.5;
-}
-
-.landing-related-list li:first-child { padding-left: 0; }
-.landing-related-list li:last-child  { padding-right: 0; border-right: 0; }
-
-.landing-related-list a {
-	color: var(--fg);
-	text-decoration: none;
-	border-bottom: 1px solid var(--rule);
-	padding-bottom: 0.15em;
-	font-size: var(--step-0);
-	align-self: start;
-}
-.landing-related-list a:hover { border-color: currentColor; }
-
-.landing-related-list .sub {
-	color: var(--fg-muted);
-	font-size: var(--step--1);
-	margin-left: 0;
-}
-
-@media (max-width: 720px) {
-	.landing-related-list {
-		grid-template-columns: 1fr;
-	}
-	.landing-related-list li {
-		padding-inline: 0;
-		border-right: 0;
-		border-bottom: 1px solid var(--rule);
-	}
-	.landing-related-list li:last-child { border-bottom: 0; }
-}
+/* Related services cross-links use the shared .services-section /
+   .services-grid component (see css/services-grid.css). */
 
 /* Next up strip (/about, /words, /contact) */
 .landing-next {

--- a/content/ai-for-engineering-teams-berlin.njk
+++ b/content/ai-for-engineering-teams-berlin.njk
@@ -7,6 +7,7 @@ const sitemap = { priority: "0.9", changefreq: "monthly" };
 {% css %}
 @layer page {
 	{% include "css/landing.css" %}
+	{% include "css/services-grid.css" %}
 }
 {% endcss %}
 
@@ -70,12 +71,27 @@ const sitemap = { priority: "0.9", changefreq: "monthly" };
 		</div>
 	</section>
 
-	<section class="landing-related" aria-label="Related services">
-		<h2>Related services</h2>
-		<ul class="landing-related-list">
-			<li><a href="/fractional-engineering-lead-berlin/">Fractional engineering lead, Berlin</a><span class="sub">Strategy, team shape, mentorship</span></li>
-			<li><a href="/software-architecture-review-berlin/">Software architecture &amp; codebase review</a><span class="sub">Scoped, two weeks, decision-grade</span></li>
-			<li><a href="/freelance-tech-lead-berlin/">Freelance tech lead, Berlin</a><span class="sub">Hands-on technical leadership</span></li>
+	<section class="services-section" aria-labelledby="related-services-heading">
+		<h2 id="related-services-heading">Related services</h2>
+		<ul class="services-grid">
+			<li class="service">
+				<span class="service-kicker">&sect; 01</span>
+				<h3 class="service-head">Fractional engineering lead</h3>
+				<p class="service-body">Senior engineering leadership, part-time. Strategy, team shape, architecture, mentorship.</p>
+				<a class="cta" href="/fractional-engineering-lead-berlin/">Fractional engineering lead</a>
+			</li>
+			<li class="service">
+				<span class="service-kicker">&sect; 02</span>
+				<h3 class="service-head">Architecture review</h3>
+				<p class="service-body">Honest read on what's load-bearing, what's rot, what's worth the rewrite. Scoped, two weeks.</p>
+				<a class="cta" href="/software-architecture-review-berlin/">Software architecture review</a>
+			</li>
+			<li class="service">
+				<span class="service-kicker">&sect; 03</span>
+				<h3 class="service-head">Freelance tech lead</h3>
+				<p class="service-body">Hands-on technical leadership. Twenty years in. Berlin, EU, remote.</p>
+				<a class="cta" href="/freelance-tech-lead-berlin/">Freelance tech lead, Berlin</a>
+			</li>
 		</ul>
 	</section>
 

--- a/content/fractional-engineering-lead-berlin.njk
+++ b/content/fractional-engineering-lead-berlin.njk
@@ -7,6 +7,7 @@ const sitemap = { priority: "0.9", changefreq: "monthly" };
 {% css %}
 @layer page {
 	{% include "css/landing.css" %}
+	{% include "css/services-grid.css" %}
 }
 {% endcss %}
 
@@ -74,12 +75,27 @@ const sitemap = { priority: "0.9", changefreq: "monthly" };
 		</div>
 	</section>
 
-	<section class="landing-related" aria-label="Related services">
-		<h2>Related services</h2>
-		<ul class="landing-related-list">
-			<li><a href="/software-architecture-review-berlin/">Software architecture &amp; codebase review</a><span class="sub">Scoped, two weeks, decision-grade</span></li>
-			<li><a href="/ai-for-engineering-teams-berlin/">AI for engineering teams</a><span class="sub">Workflows, guardrails, team health</span></li>
-			<li><a href="/freelance-tech-lead-berlin/">Freelance tech lead, Berlin</a><span class="sub">Hands-on technical leadership</span></li>
+	<section class="services-section" aria-labelledby="related-services-heading">
+		<h2 id="related-services-heading">Related services</h2>
+		<ul class="services-grid">
+			<li class="service">
+				<span class="service-kicker">&sect; 01</span>
+				<h3 class="service-head">Architecture review</h3>
+				<p class="service-body">Honest read on what's load-bearing, what's rot, what's worth the rewrite. Scoped, two weeks.</p>
+				<a class="cta" href="/software-architecture-review-berlin/">Software architecture review</a>
+			</li>
+			<li class="service">
+				<span class="service-kicker">&sect; 02</span>
+				<h3 class="service-head">AI for engineering teams</h3>
+				<p class="service-body">Workflow design, guardrails, team health. AI every day, without rotting the codebase or the craft.</p>
+				<a class="cta" href="/ai-for-engineering-teams-berlin/">AI for engineering teams</a>
+			</li>
+			<li class="service">
+				<span class="service-kicker">&sect; 03</span>
+				<h3 class="service-head">Freelance tech lead</h3>
+				<p class="service-body">Hands-on technical leadership. Twenty years in. Berlin, EU, remote.</p>
+				<a class="cta" href="/freelance-tech-lead-berlin/">Freelance tech lead, Berlin</a>
+			</li>
 		</ul>
 	</section>
 

--- a/content/freelance-frontend-developer-berlin.njk
+++ b/content/freelance-frontend-developer-berlin.njk
@@ -7,6 +7,7 @@ const sitemap = { priority: "0.9", changefreq: "monthly" };
 {% css %}
 @layer page {
 	{% include "css/landing.css" %}
+	{% include "css/services-grid.css" %}
 }
 {% endcss %}
 
@@ -69,12 +70,27 @@ const sitemap = { priority: "0.9", changefreq: "monthly" };
 		</div>
 	</section>
 
-	<section class="landing-related" aria-label="Related services">
-		<h2>Related services</h2>
-		<ul class="landing-related-list">
-			<li><a href="/freelance-full-stack-developer-berlin/">Freelance full-stack developer, Berlin</a><span class="sub">End-to-end product surfaces, TS/Node</span></li>
-			<li><a href="/fractional-engineering-lead-berlin/">Fractional engineering lead, Berlin</a><span class="sub">Strategy, team shape, mentorship</span></li>
-			<li><a href="/freelance-tech-lead-berlin/">Freelance tech lead, Berlin</a><span class="sub">Hands-on technical leadership</span></li>
+	<section class="services-section" aria-labelledby="related-services-heading">
+		<h2 id="related-services-heading">Related services</h2>
+		<ul class="services-grid">
+			<li class="service">
+				<span class="service-kicker">&sect; 01</span>
+				<h3 class="service-head">Freelance full-stack</h3>
+				<p class="service-body">End-to-end product surfaces. TypeScript top to bottom. Node or BFF in the middle.</p>
+				<a class="cta" href="/freelance-full-stack-developer-berlin/">Freelance full-stack in Berlin</a>
+			</li>
+			<li class="service">
+				<span class="service-kicker">&sect; 02</span>
+				<h3 class="service-head">Fractional engineering lead</h3>
+				<p class="service-body">Senior engineering leadership, part-time. Strategy, team shape, architecture, mentorship.</p>
+				<a class="cta" href="/fractional-engineering-lead-berlin/">Fractional engineering lead</a>
+			</li>
+			<li class="service">
+				<span class="service-kicker">&sect; 03</span>
+				<h3 class="service-head">Freelance tech lead</h3>
+				<p class="service-body">Hands-on technical leadership. Twenty years in. Berlin, EU, remote.</p>
+				<a class="cta" href="/freelance-tech-lead-berlin/">Freelance tech lead, Berlin</a>
+			</li>
 		</ul>
 	</section>
 

--- a/content/freelance-full-stack-developer-berlin.njk
+++ b/content/freelance-full-stack-developer-berlin.njk
@@ -7,6 +7,7 @@ const sitemap = { priority: "0.9", changefreq: "monthly" };
 {% css %}
 @layer page {
 	{% include "css/landing.css" %}
+	{% include "css/services-grid.css" %}
 }
 {% endcss %}
 
@@ -69,12 +70,27 @@ const sitemap = { priority: "0.9", changefreq: "monthly" };
 		</div>
 	</section>
 
-	<section class="landing-related" aria-label="Related services">
-		<h2>Related services</h2>
-		<ul class="landing-related-list">
-			<li><a href="/freelance-frontend-developer-berlin/">Freelance frontend developer, Berlin</a><span class="sub">React, TypeScript, design systems</span></li>
-			<li><a href="/fractional-engineering-lead-berlin/">Fractional engineering lead, Berlin</a><span class="sub">Strategy, team shape, mentorship</span></li>
-			<li><a href="/freelance-tech-lead-berlin/">Freelance tech lead, Berlin</a><span class="sub">Hands-on technical leadership</span></li>
+	<section class="services-section" aria-labelledby="related-services-heading">
+		<h2 id="related-services-heading">Related services</h2>
+		<ul class="services-grid">
+			<li class="service">
+				<span class="service-kicker">&sect; 01</span>
+				<h3 class="service-head">Freelance frontend</h3>
+				<p class="service-body">React, TypeScript, modern CSS. Accessible, performant interfaces. Design systems that stay coherent.</p>
+				<a class="cta" href="/freelance-frontend-developer-berlin/">Freelance frontend in Berlin</a>
+			</li>
+			<li class="service">
+				<span class="service-kicker">&sect; 02</span>
+				<h3 class="service-head">Fractional engineering lead</h3>
+				<p class="service-body">Senior engineering leadership, part-time. Strategy, team shape, architecture, mentorship.</p>
+				<a class="cta" href="/fractional-engineering-lead-berlin/">Fractional engineering lead</a>
+			</li>
+			<li class="service">
+				<span class="service-kicker">&sect; 03</span>
+				<h3 class="service-head">Freelance tech lead</h3>
+				<p class="service-body">Hands-on technical leadership. Twenty years in. Berlin, EU, remote.</p>
+				<a class="cta" href="/freelance-tech-lead-berlin/">Freelance tech lead, Berlin</a>
+			</li>
 		</ul>
 	</section>
 

--- a/content/software-architecture-review-berlin.njk
+++ b/content/software-architecture-review-berlin.njk
@@ -7,6 +7,7 @@ const sitemap = { priority: "0.9", changefreq: "monthly" };
 {% css %}
 @layer page {
 	{% include "css/landing.css" %}
+	{% include "css/services-grid.css" %}
 }
 {% endcss %}
 
@@ -75,12 +76,27 @@ const sitemap = { priority: "0.9", changefreq: "monthly" };
 		</div>
 	</section>
 
-	<section class="landing-related" aria-label="Related services">
-		<h2>Related services</h2>
-		<ul class="landing-related-list">
-			<li><a href="/fractional-engineering-lead-berlin/">Fractional engineering lead, Berlin</a><span class="sub">Strategy, team shape, mentorship</span></li>
-			<li><a href="/ai-for-engineering-teams-berlin/">AI for engineering teams</a><span class="sub">Workflows, guardrails, team health</span></li>
-			<li><a href="/freelance-tech-lead-berlin/">Freelance tech lead, Berlin</a><span class="sub">Hands-on technical leadership</span></li>
+	<section class="services-section" aria-labelledby="related-services-heading">
+		<h2 id="related-services-heading">Related services</h2>
+		<ul class="services-grid">
+			<li class="service">
+				<span class="service-kicker">&sect; 01</span>
+				<h3 class="service-head">Fractional engineering lead</h3>
+				<p class="service-body">Senior engineering leadership, part-time. Strategy, team shape, architecture, mentorship.</p>
+				<a class="cta" href="/fractional-engineering-lead-berlin/">Fractional engineering lead</a>
+			</li>
+			<li class="service">
+				<span class="service-kicker">&sect; 02</span>
+				<h3 class="service-head">AI for engineering teams</h3>
+				<p class="service-body">Workflow design, guardrails, team health. AI every day, without rotting the codebase or the craft.</p>
+				<a class="cta" href="/ai-for-engineering-teams-berlin/">AI for engineering teams</a>
+			</li>
+			<li class="service">
+				<span class="service-kicker">&sect; 03</span>
+				<h3 class="service-head">Freelance tech lead</h3>
+				<p class="service-body">Hands-on technical leadership. Twenty years in. Berlin, EU, remote.</p>
+				<a class="cta" href="/freelance-tech-lead-berlin/">Freelance tech lead, Berlin</a>
+			</li>
 		</ul>
 	</section>
 


### PR DESCRIPTION
## Summary

Applies the shared **.services-section / .services-grid / .service** card styling to the "Related services" strip on every SEO landing page, so the visual vocabulary matches the "Currently open for" grids on /about, /contact and the "All services" grid on the hub.

### Per-page markup (3 sibling cards)

- \`<section class="services-section">\` + \`<h2>Related services</h2>\`
- \`<ul class="services-grid">\` of \`<li class="service">\` cards
- Each card: § kicker + \`.service-head\` + \`.service-body\` + \`a.cta\`

Copy for heads / bodies / CTA labels pulled directly from the shared \`services-grid.njk\` partial, so Related and the canonical catalogue stay in sync.

### Pages touched

- /fractional-engineering-lead-berlin/
- /software-architecture-review-berlin/
- /ai-for-engineering-teams-berlin/
- /freelance-frontend-developer-berlin/
- /freelance-full-stack-developer-berlin/

(/freelance-tech-lead-berlin/ doesn't have a Related strip — it uses "All services" via the shared partial.)

### CSS

- \`_includes/css/landing.css\` — removed the now-unused \`.landing-related\*\` ruleset (~65 lines).
- Each landing page now includes both \`css/landing.css\` and \`css/services-grid.css\`.

## Test plan

- [x] \`npm run build\` clean.
- [x] Playwright probe × 5 pages × 2 viewports — all show \`.services-section\` with \`.services-grid\` at 3 columns desktop / 1 column mobile; each with 3 cards (kicker + head + body + cta); no old \`.landing-related-list\` markup remains; no horizontal overflow.
- [ ] Visual pass on live Netlify preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)